### PR TITLE
chore: update claude-code-review workflow config

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,9 @@ jobs:
           # Enable progress tracking
           track_progress: true
 
+          # Claude only posts its review once and updates it
+          use_sticky_comment: true
+
           # Your custom review instructions
           prompt: |
             REPO: ${{ github.repository }}
@@ -63,7 +66,7 @@ jobs:
                - Check API documentation accuracy
 
             Provide detailed feedback using inline comments for specific issues.
-            Use top-level comments for general observations or praise.
+            The top level comment should be kept short with minimal repeating or verbosity. To avoid creating unnecessary comments repetedly, use `gh pr comment --edit-last`.
 
           # Tools for comprehensive PR review
           claude_args: |


### PR DESCRIPTION
Enable sticky comments and refine review instructions to reduce verbosity.

Its normal to see an error on the claude code review job for now (it auto fails if the content of the CI file has changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)