### PR TITLE
Reduce code duplication

### DIFF
--- a/src/CowEvcBaseWrapper.sol
+++ b/src/CowEvcBaseWrapper.sol
@@ -59,16 +59,14 @@ abstract contract CowEvcBaseWrapper is CowWrapper, PreApprovedHashes {
         After
     }
 
-    constructor(address _evc, ICowSettlement _settlement) CowWrapper(_settlement) {
+    constructor(address _evc, ICowSettlement _settlement, bytes32 _domainName, bytes32 _domainVersion)
+        CowWrapper(_settlement)
+    {
         require(_evc.code.length > 0, "EVC address is invalid");
         EVC = IEVC(_evc);
-        // forge-lint: disable-next-line(asm-keccak256)
-        bytes32 domainNameHash = keccak256(bytes(domainName()));
-        // forge-lint: disable-next-line(asm-keccak256)
-        bytes32 domainVersionHash = keccak256(bytes(domainVersion()));
         NONCE_NAMESPACE = uint256(uint160(address(this)));
         DOMAIN_SEPARATOR =
-            keccak256(abi.encode(DOMAIN_TYPE_HASH, domainNameHash, domainVersionHash, block.chainid, address(this)));
+            keccak256(abi.encode(DOMAIN_TYPE_HASH, _domainName, _domainVersion, block.chainid, address(this)));
     }
 
     function _encodeSignedBatchItems(ParamsLocation paramsLocation)
@@ -185,10 +183,4 @@ abstract contract CowEvcBaseWrapper is CowWrapper, PreApprovedHashes {
         bytes calldata wrapperData,
         bytes calldata remainingWrapperData
     ) internal virtual;
-
-    /// @return The EIP-712 domain name used for computing the domain separator.
-    function domainName() internal pure virtual returns (string memory);
-
-    /// @return The EIP-712 domain version used for computing the domain separator.
-    function domainVersion() internal pure virtual returns (string memory);
 }

--- a/src/CowEvcBaseWrapper.sol
+++ b/src/CowEvcBaseWrapper.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8;
+
+import {IEVC} from "evc/EthereumVaultConnector.sol";
+
+import {CowWrapper, ICowSettlement} from "./CowWrapper.sol";
+import {PreApprovedHashes} from "./PreApprovedHashes.sol";
+
+/// @title CowEvcBaseWrapper
+/// @notice Shared components for implementing Euler wrappers.
+abstract contract CowEvcBaseWrapper is CowWrapper, PreApprovedHashes {
+    IEVC public immutable EVC;
+
+    /// @dev The EIP-712 domain type hash used for computing the domain
+    /// separator.
+    bytes32 internal constant DOMAIN_TYPE_HASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+    /// @dev The marker value for a sell order for computing the order struct
+    /// hash. This allows the EIP-712 compatible wallets to display a
+    /// descriptive string for the order kind (instead of 0 or 1).
+    bytes32 internal constant KIND_SELL = keccak256("sell");
+
+    /// @dev The OrderKind marker value for a buy order for computing the order
+    /// struct hash.
+    bytes32 internal constant KIND_BUY = keccak256("buy");
+
+    /// @dev Used by EIP-712 signing to prevent signatures from being replayed
+    bytes32 public immutable DOMAIN_SEPARATOR;
+
+    //// @dev The EVC nonce namespace to use when calling `EVC.permit` to authorize this contract.
+    uint256 public immutable NONCE_NAMESPACE;
+
+    uint256 internal immutable PARAMS_SIZE;
+
+    /// @dev Indicates that the current operation cannot be completed with the given msgSender
+    error Unauthorized(address msgSender);
+
+    /// @dev Indicates that the pre-approved hash is no longer able to be executed because the block timestamp is too old
+    error OperationDeadlineExceeded(uint256 validToTimestamp, uint256 currentTimestamp);
+
+    /// @dev Indicates that this contract did not receive enough repayment assets from the settlement contract in order to cover all user's orders
+    error InsufficientRepaymentAsset(address vault, uint256 balanceAmount, uint256 repayAmount);
+
+    /// @dev Indicates that a user attempted to interact with an account that is not their own
+    error SubaccountMustBeControlledByOwner(address subaccount, address owner);
+
+    /// @dev Indicates that the EVC called `evcInternalSettle` in an invalid way
+    error InvalidCallback();
+
+    /// @dev Used to ensure that the EVC is calling back this contract with the correct data
+    bytes32 internal transient expectedEvcInternalSettleCallHash;
+
+    constructor(address _evc, ICowSettlement _settlement) CowWrapper(_settlement) {
+        require(_evc.code.length > 0, "EVC address is invalid");
+        EVC = IEVC(_evc);
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 domainNameHash = keccak256(bytes(domainName()));
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 domainVersionHash = keccak256(bytes(domainVersion()));
+        NONCE_NAMESPACE = uint256(uint160(address(this)));
+        DOMAIN_SEPARATOR =
+            keccak256(abi.encode(DOMAIN_TYPE_HASH, domainNameHash, domainVersionHash, block.chainid, address(this)));
+    }
+
+    /// @dev This function makes strong assumptions on the memory layout of the struct in memory.
+    /// It assumes:
+    ///  - The struct itself doesn't contain any dynamic-length types.
+    ///  - The struct is encoded in memory with zero padding.
+    function _getApprovalHash(bytes32 paramsMemoryLocation) internal view returns (bytes32 digest) {
+        bytes32 structHash;
+        bytes32 separator = DOMAIN_SEPARATOR;
+        uint256 paramsSize = PARAMS_SIZE;
+        assembly ("memory-safe") {
+            structHash := keccak256(paramsMemoryLocation, paramsSize)
+            let ptr := mload(0x40)
+            mstore(ptr, "\x19\x01")
+            mstore(add(ptr, 0x02), separator)
+            mstore(add(ptr, 0x22), structHash)
+            digest := keccak256(ptr, 0x42)
+        }
+    }
+
+    /// @notice Internal settlement function called by EVC
+    function evcInternalSettle(
+        bytes calldata settleData,
+        bytes calldata wrapperData,
+        bytes calldata remainingWrapperData
+    ) external payable {
+        require(msg.sender == address(EVC), Unauthorized(msg.sender));
+        require(expectedEvcInternalSettleCallHash == keccak256(msg.data), InvalidCallback());
+        expectedEvcInternalSettleCallHash = bytes32(0);
+        _evcInternalSettle(settleData, wrapperData, remainingWrapperData);
+    }
+
+    function _evcInternalSettle(
+        bytes calldata settleData,
+        bytes calldata wrapperData,
+        bytes calldata remainingWrapperData
+    ) internal virtual;
+
+    /// @return The EIP-712 domain name used for computing the domain separator.
+    function domainName() internal pure virtual returns (string memory);
+
+    /// @return The EIP-712 domain version used for computing the domain separator.
+    function domainVersion() internal pure virtual returns (string memory);
+}

--- a/src/CowEvcClosePositionWrapper.sol
+++ b/src/CowEvcClosePositionWrapper.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8;
 
 import {IEVC} from "evc/EthereumVaultConnector.sol";
 
-import {CowWrapper, ICowSettlement} from "./CowWrapper.sol";
+import {ICowSettlement} from "./CowWrapper.sol";
 import {IERC4626, IBorrowing, IERC20} from "euler-vault-kit/src/EVault/IEVault.sol";
 import {SafeERC20Lib} from "euler-vault-kit/src/EVault/shared/lib/SafeERC20Lib.sol";
-import {PreApprovedHashes} from "./PreApprovedHashes.sol";
+import {CowEvcBaseWrapper} from "./CowEvcBaseWrapper.sol";
 
 /// @title CowEvcClosePositionWrapper
 /// @notice A specialized wrapper for closing leveraged positions with EVC
@@ -19,54 +19,9 @@ import {PreApprovedHashes} from "./PreApprovedHashes.sol";
 /// the order should be of type GPv2Order.KIND_BUY to prevent excess from being sent to the contract.
 /// If a full close is being performed, leave a small buffer for intrest accumultation, and the dust will
 /// be returned to the owner's wallet.
-contract CowEvcClosePositionWrapper is CowWrapper, PreApprovedHashes {
-    IEVC public immutable EVC;
-
-    /// @dev The EIP-712 domain type hash used for computing the domain
-    /// separator.
-    bytes32 private constant DOMAIN_TYPE_HASH =
-        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
-
-    /// @dev The EIP-712 domain name used for computing the domain separator.
-    bytes32 private constant DOMAIN_NAME = keccak256("CowEvcClosePositionWrapper");
-
-    /// @dev The EIP-712 domain version used for computing the domain separator.
-    bytes32 private constant DOMAIN_VERSION = keccak256("1");
-
-    /// @dev The marker value for a sell order for computing the order struct
-    /// hash. This allows the EIP-712 compatible wallets to display a
-    /// descriptive string for the order kind (instead of 0 or 1).
-    bytes32 private constant KIND_SELL = keccak256("sell");
-
-    /// @dev The OrderKind marker value for a buy order for computing the order
-    /// struct hash.
-    bytes32 private constant KIND_BUY = keccak256("buy");
-
-    /// @dev Used by EIP-712 signing to prevent signatures from being replayed
-    bytes32 public immutable DOMAIN_SEPARATOR;
-
-    //// @dev The EVC nonce namespace to use when calling `EVC.permit` to authorize this contract.
-    uint256 public immutable NONCE_NAMESPACE;
-
+contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
     /// @dev A descriptive label for this contract, as required by CowWrapper
     string public override name = "Euler EVC - Close Position";
-
-    uint256 private immutable PARAMS_SIZE;
-
-    /// @dev Indicates that the current operation cannot be completed with the given msgSender
-    error Unauthorized(address msgSender);
-
-    /// @dev Indicates that the pre-approved hash is no longer able to be executed because the block timestamp is too old
-    error OperationDeadlineExceeded(uint256 validToTimestamp, uint256 currentTimestamp);
-
-    /// @dev Indicates that this contract did not receive enough repayment assets from the settlement contract in order to cover all user's orders
-    error InsufficientRepaymentAsset(address vault, uint256 balanceAmount, uint256 repayAmount);
-
-    /// @dev Indicates that a user attempted to interact with an account that is not their own
-    error SubaccountMustBeControlledByOwner(address subaccount, address owner);
-
-    /// @dev Indicates that the EVC called `evcInternalSettle` in an invalid way
-    error InvalidCallback();
 
     /// @dev Emitted when a position is closed via this wrapper
     event CowEvcPositionClosed(
@@ -79,11 +34,7 @@ contract CowEvcClosePositionWrapper is CowWrapper, PreApprovedHashes {
         bytes32 kind
     );
 
-    /// @dev Used to ensure that the EVC is calling back this contract with the correct data
-    bytes32 internal transient expectedEvcInternalSettleCallHash;
-
-    constructor(address _evc, ICowSettlement _settlement) CowWrapper(_settlement) {
-        require(_evc.code.length > 0, "EVC address is invalid");
+    constructor(address _evc, ICowSettlement _settlement) CowEvcBaseWrapper(_evc, _settlement) {
         PARAMS_SIZE =
         abi.encode(
             ClosePositionParams({
@@ -98,11 +49,6 @@ contract CowEvcClosePositionWrapper is CowWrapper, PreApprovedHashes {
             })
         )
         .length;
-        EVC = IEVC(_evc);
-        NONCE_NAMESPACE = uint256(uint160(address(this)));
-
-        DOMAIN_SEPARATOR =
-            keccak256(abi.encode(DOMAIN_TYPE_HASH, DOMAIN_NAME, DOMAIN_VERSION, block.chainid, address(this)));
     }
 
     /// @notice The information necessary to close a debt position against an euler vault by repaying debt and returning collateral
@@ -161,17 +107,11 @@ contract CowEvcClosePositionWrapper is CowWrapper, PreApprovedHashes {
     }
 
     function _getApprovalHash(ClosePositionParams memory params) internal view returns (bytes32 digest) {
-        bytes32 structHash;
-        bytes32 separator = DOMAIN_SEPARATOR;
-        uint256 paramsSize = PARAMS_SIZE;
+        bytes32 paramsMemoryLocation;
         assembly ("memory-safe") {
-            structHash := keccak256(params, paramsSize)
-            let ptr := mload(0x40)
-            mstore(ptr, "\x19\x01")
-            mstore(add(ptr, 0x02), separator)
-            mstore(add(ptr, 0x22), structHash)
-            digest := keccak256(ptr, 0x42)
+            paramsMemoryLocation := params
         }
+        return _getApprovalHash(paramsMemoryLocation);
     }
 
     function parseWrapperData(bytes calldata wrapperData)
@@ -312,26 +252,12 @@ contract CowEvcClosePositionWrapper is CowWrapper, PreApprovedHashes {
         );
     }
 
-    /// @notice Internal settlement function called by EVC
-    function evcInternalSettle(
+    function _evcInternalSettle(
         bytes calldata settleData,
         bytes calldata wrapperData,
         bytes calldata remainingWrapperData
-    ) external payable {
-        require(msg.sender == address(EVC), Unauthorized(msg.sender));
-        require(expectedEvcInternalSettleCallHash == keccak256(msg.data), InvalidCallback());
-        expectedEvcInternalSettleCallHash = bytes32(0);
-
-        ClosePositionParams memory params;
-        (params,,) = _parseClosePositionParams(wrapperData);
-        _evcInternalSettle(settleData, remainingWrapperData, params);
-    }
-
-    function _evcInternalSettle(
-        bytes calldata settleData,
-        bytes calldata remainingWrapperData,
-        ClosePositionParams memory params
-    ) internal {
+    ) internal override {
+        (ClosePositionParams memory params,,) = _parseClosePositionParams(wrapperData);
         // If a subaccount is being used, we need to transfer the required amount of collateral for the trade into the owner's wallet.
         // This is required becuase the settlement contract can only pull funds from the wallet that signed the transaction.
         // Since its not possible for a subaccount to sign a transaction due to the private key not existing and their being no
@@ -378,5 +304,15 @@ contract CowEvcClosePositionWrapper is CowWrapper, PreApprovedHashes {
                 );
             }
         }
+    }
+
+    /// @inheritdoc CowEvcBaseWrapper
+    function domainName() internal pure override returns (string memory) {
+        return "CowEvcClosePositionWrapper";
+    }
+
+    /// @inheritdoc CowEvcBaseWrapper
+    function domainVersion() internal pure override returns (string memory) {
+        return "1";
     }
 }

--- a/src/CowEvcClosePositionWrapper.sol
+++ b/src/CowEvcClosePositionWrapper.sol
@@ -20,6 +20,12 @@ import {CowEvcBaseWrapper} from "./CowEvcBaseWrapper.sol";
 /// If a full close is being performed, leave a small buffer for intrest accumultation, and the dust will
 /// be returned to the owner's wallet.
 contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
+    /// @dev The EIP-712 domain name used for computing the domain separator.
+    bytes32 constant DOMAIN_NAME = keccak256("CowEvcClosePositionWrapper");
+
+    /// @dev The EIP-712 domain version used for computing the domain separator.
+    bytes32 constant DOMAIN_VERSION = keccak256("1");
+
     /// @dev A descriptive label for this contract, as required by CowWrapper
     string public override name = "Euler EVC - Close Position";
 
@@ -34,7 +40,9 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         bytes32 kind
     );
 
-    constructor(address _evc, ICowSettlement _settlement) CowEvcBaseWrapper(_evc, _settlement) {
+    constructor(address _evc, ICowSettlement _settlement)
+        CowEvcBaseWrapper(_evc, _settlement, DOMAIN_NAME, DOMAIN_VERSION)
+    {
         PARAMS_SIZE =
         abi.encode(
             ClosePositionParams({
@@ -251,16 +259,6 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
                 );
             }
         }
-    }
-
-    /// @inheritdoc CowEvcBaseWrapper
-    function domainName() internal pure override returns (string memory) {
-        return "CowEvcClosePositionWrapper";
-    }
-
-    /// @inheritdoc CowEvcBaseWrapper
-    function domainVersion() internal pure override returns (string memory) {
-        return "1";
     }
 
     function memoryLocation(ClosePositionParams memory params) internal pure returns (ParamsLocation location) {

--- a/src/CowEvcCollateralSwapWrapper.sol
+++ b/src/CowEvcCollateralSwapWrapper.sol
@@ -16,6 +16,12 @@ import {CowEvcBaseWrapper} from "./CowEvcBaseWrapper.sol";
 ///      3. Execute settlement to swap collateral (new collateral is deposited directly into user's account)
 ///      All operations are atomic within EVC batch
 contract CowEvcCollateralSwapWrapper is CowEvcBaseWrapper {
+    /// @dev The EIP-712 domain name used for computing the domain separator.
+    bytes32 constant DOMAIN_NAME = keccak256("CowEvcCollateralSwapWrapper");
+
+    /// @dev The EIP-712 domain version used for computing the domain separator.
+    bytes32 constant DOMAIN_VERSION = keccak256("1");
+
     /// @dev A descriptive label for this contract, as required by CowWrapper
     string public override name = "Euler EVC - Collateral Swap";
 
@@ -29,7 +35,9 @@ contract CowEvcCollateralSwapWrapper is CowEvcBaseWrapper {
         bytes32 kind
     );
 
-    constructor(address _evc, ICowSettlement _settlement) CowEvcBaseWrapper(_evc, _settlement) {
+    constructor(address _evc, ICowSettlement _settlement)
+        CowEvcBaseWrapper(_evc, _settlement, DOMAIN_NAME, DOMAIN_VERSION)
+    {
         PARAMS_SIZE =
         abi.encode(
             CollateralSwapParams({
@@ -208,16 +216,6 @@ contract CowEvcCollateralSwapWrapper is CowEvcBaseWrapper {
                 );
             }
         }
-    }
-
-    /// @inheritdoc CowEvcBaseWrapper
-    function domainName() internal pure override returns (string memory) {
-        return "CowEvcCollateralSwapWrapper";
-    }
-
-    /// @inheritdoc CowEvcBaseWrapper
-    function domainVersion() internal pure override returns (string memory) {
-        return "1";
     }
 
     function memoryLocation(CollateralSwapParams memory params) internal pure returns (ParamsLocation location) {

--- a/src/CowEvcOpenPositionWrapper.sol
+++ b/src/CowEvcOpenPositionWrapper.sol
@@ -19,6 +19,12 @@ import {CowEvcBaseWrapper} from "./CowEvcBaseWrapper.sol";
 /// swap should be the `owner` (not this contract). Furthermore, the buyAmountIn should
 /// be the same as `maxRepayAmount`.
 contract CowEvcOpenPositionWrapper is CowEvcBaseWrapper {
+    /// @dev The EIP-712 domain name used for computing the domain separator.
+    bytes32 constant DOMAIN_NAME = keccak256("CowEvcOpenPositionWrapper");
+
+    /// @dev The EIP-712 domain version used for computing the domain separator.
+    bytes32 constant DOMAIN_VERSION = keccak256("1");
+
     /// @dev A descriptive label for this contract, as required by CowWrapper
     string public override name = "Euler EVC - Open Position";
 
@@ -32,7 +38,9 @@ contract CowEvcOpenPositionWrapper is CowEvcBaseWrapper {
         uint256 borrowAmount
     );
 
-    constructor(address _evc, ICowSettlement _settlement) CowEvcBaseWrapper(_evc, _settlement) {
+    constructor(address _evc, ICowSettlement _settlement)
+        CowEvcBaseWrapper(_evc, _settlement, DOMAIN_NAME, DOMAIN_VERSION)
+    {
         PARAMS_SIZE =
         abi.encode(
             OpenPositionParams({
@@ -193,16 +201,6 @@ contract CowEvcOpenPositionWrapper is CowEvcBaseWrapper {
         // Use GPv2Wrapper's _internalSettle to call the settlement contract
         // wrapperData is empty since we've already processed it in _wrap
         _next(settleData, remainingWrapperData);
-    }
-
-    /// @inheritdoc CowEvcBaseWrapper
-    function domainName() internal pure override returns (string memory) {
-        return "CowEvcOpenPositionWrapper";
-    }
-
-    /// @inheritdoc CowEvcBaseWrapper
-    function domainVersion() internal pure override returns (string memory) {
-        return "1";
     }
 
     function memoryLocation(OpenPositionParams memory params) internal pure returns (ParamsLocation location) {

--- a/test/CowEvcClosePositionWrapper.t.sol
+++ b/test/CowEvcClosePositionWrapper.t.sol
@@ -7,6 +7,7 @@ import {IEVC} from "evc/EthereumVaultConnector.sol";
 import {IEVault, IERC4626, IERC20} from "euler-vault-kit/src/EVault/IEVault.sol";
 
 import {CowEvcClosePositionWrapper} from "../src/CowEvcClosePositionWrapper.sol";
+import {CowEvcBaseWrapper} from "../src/CowEvcBaseWrapper.sol";
 import {ICowSettlement, CowWrapper} from "../src/CowWrapper.sol";
 import {GPv2AllowListAuthentication} from "cow/GPv2AllowListAuthentication.sol";
 import {PreApprovedHashes} from "../src/PreApprovedHashes.sol";
@@ -268,7 +269,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
         bytes memory wrapperData = "";
 
         // Try to call evcInternalSettle directly (not through EVC)
-        vm.expectRevert(abi.encodeWithSelector(CowEvcClosePositionWrapper.Unauthorized.selector, address(this)));
+        vm.expectRevert(abi.encodeWithSelector(CowEvcBaseWrapper.Unauthorized.selector, address(this)));
         closePositionWrapper.evcInternalSettle(settleData, wrapperData, wrapperData);
     }
 

--- a/test/CowEvcCollateralSwapWrapper.t.sol
+++ b/test/CowEvcCollateralSwapWrapper.t.sol
@@ -6,6 +6,7 @@ import {GPv2Order} from "cow/libraries/GPv2Order.sol";
 import {IEVC} from "evc/EthereumVaultConnector.sol";
 import {IEVault, IERC4626, IERC20} from "euler-vault-kit/src/EVault/IEVault.sol";
 
+import {CowEvcBaseWrapper} from "../src/CowEvcBaseWrapper.sol";
 import {CowEvcCollateralSwapWrapper} from "../src/CowEvcCollateralSwapWrapper.sol";
 import {ICowSettlement, CowWrapper} from "../src/CowWrapper.sol";
 import {GPv2AllowListAuthentication} from "cow/GPv2AllowListAuthentication.sol";
@@ -322,8 +323,8 @@ contract CowEvcCollateralSwapWrapperTest is CowBaseTest {
         bytes memory wrapperData = "";
 
         // Try to call evcInternalSwap directly (not through EVC)
-        vm.expectRevert(abi.encodeWithSelector(CowEvcCollateralSwapWrapper.Unauthorized.selector, address(this)));
-        collateralSwapWrapper.evcInternalSwap(settleData, wrapperData, wrapperData);
+        vm.expectRevert(abi.encodeWithSelector(CowEvcBaseWrapper.Unauthorized.selector, address(this)));
+        collateralSwapWrapper.evcInternalSettle(settleData, wrapperData, wrapperData);
     }
 
     /// @notice Test that non-solvers cannot call wrappedSettle

--- a/test/CowEvcOpenPositionWrapper.t.sol
+++ b/test/CowEvcOpenPositionWrapper.t.sol
@@ -5,6 +5,7 @@ import {GPv2Order} from "cow/libraries/GPv2Order.sol";
 
 import {IEVault, IERC4626, IERC20} from "euler-vault-kit/src/EVault/IEVault.sol";
 
+import {CowEvcBaseWrapper} from "../src/CowEvcOpenPositionWrapper.sol";
 import {CowEvcOpenPositionWrapper} from "../src/CowEvcOpenPositionWrapper.sol";
 import {ICowSettlement, CowWrapper} from "../src/CowWrapper.sol";
 import {GPv2AllowListAuthentication} from "cow/GPv2AllowListAuthentication.sol";
@@ -215,8 +216,8 @@ contract CowEvcOpenPositionWrapperTest is CowBaseTest {
         bytes memory wrapperData = "";
 
         // Try to call evcInternalSettle directly (not through EVC)
-        vm.expectRevert(abi.encodeWithSelector(CowEvcOpenPositionWrapper.Unauthorized.selector, address(this)));
-        openPositionWrapper.evcInternalSettle(settleData, wrapperData);
+        vm.expectRevert(abi.encodeWithSelector(CowEvcBaseWrapper.Unauthorized.selector, address(this)));
+        openPositionWrapper.evcInternalSettle(settleData, hex"", wrapperData);
     }
 
     /// @notice Test that non-solvers cannot call wrappedSettle

--- a/test/unit/CowEvcClosePositionWrapper.unit.t.sol
+++ b/test/unit/CowEvcClosePositionWrapper.unit.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8;
 import {Test} from "forge-std/Test.sol";
 import {IEVC} from "evc/EthereumVaultConnector.sol";
 import {CowEvcClosePositionWrapper} from "../../src/CowEvcClosePositionWrapper.sol";
+import {CowEvcBaseWrapper} from "../../src/CowEvcBaseWrapper.sol";
 import {ICowSettlement} from "../../src/CowWrapper.sol";
 import {MockEVC} from "./mocks/MockEVC.sol";
 import {MockCowAuthentication, MockCowSettlement} from "./mocks/MockCowProtocol.sol";
@@ -395,7 +396,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
     }
 
     function test_HelperRepay_OnlyEVC() public {
-        vm.expectRevert(abi.encodeWithSelector(CowEvcClosePositionWrapper.Unauthorized.selector, address(this)));
+        vm.expectRevert(abi.encodeWithSelector(CowEvcBaseWrapper.Unauthorized.selector, address(this)));
         wrapper.helperRepay(address(mockBorrowVault), OWNER, ACCOUNT);
     }
 
@@ -421,7 +422,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         });
 
         vm.prank(address(mockEvc));
-        vm.expectRevert(abi.encodeWithSelector(CowEvcClosePositionWrapper.Unauthorized.selector, wrongAccount));
+        vm.expectRevert(abi.encodeWithSelector(CowEvcBaseWrapper.Unauthorized.selector, wrongAccount));
         mockEvc.batch(items);
     }
 
@@ -434,7 +435,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         bytes memory wrapperData = "";
         bytes memory remainingWrapperData = "";
 
-        vm.expectRevert(abi.encodeWithSelector(CowEvcClosePositionWrapper.Unauthorized.selector, address(this)));
+        vm.expectRevert(abi.encodeWithSelector(CowEvcBaseWrapper.Unauthorized.selector, address(this)));
         wrapper.evcInternalSettle(settleData, wrapperData, remainingWrapperData);
     }
 
@@ -457,7 +458,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         );
 
         vm.prank(address(mockEvc));
-        vm.expectRevert(CowEvcClosePositionWrapper.InvalidCallback.selector);
+        vm.expectRevert(CowEvcBaseWrapper.InvalidCallback.selector);
         wrapper.evcInternalSettle(settleData, wrapperData, remainingWrapperData);
     }
 
@@ -601,7 +602,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         vm.prank(address(mockEvc));
         vm.expectRevert(
             abi.encodeWithSelector(
-                CowEvcClosePositionWrapper.SubaccountMustBeControlledByOwner.selector, invalidSubaccount, OWNER
+                CowEvcBaseWrapper.SubaccountMustBeControlledByOwner.selector, invalidSubaccount, OWNER
             )
         );
         wrapper.evcInternalSettle(settleData, wrapperData, remainingWrapperData);
@@ -723,7 +724,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         vm.prank(SOLVER);
         vm.expectRevert(
             abi.encodeWithSelector(
-                CowEvcClosePositionWrapper.OperationDeadlineExceeded.selector, params.deadline, block.timestamp
+                CowEvcBaseWrapper.OperationDeadlineExceeded.selector, params.deadline, block.timestamp
             )
         );
         wrapper.wrappedSettle(settleData, wrapperData);

--- a/test/unit/CowEvcOpenPositionWrapper.unit.t.sol
+++ b/test/unit/CowEvcOpenPositionWrapper.unit.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8;
 import {Test} from "forge-std/Test.sol";
 import {IEVC} from "evc/EthereumVaultConnector.sol";
 import {CowEvcOpenPositionWrapper} from "../../src/CowEvcOpenPositionWrapper.sol";
+import {CowEvcBaseWrapper} from "../../src/CowEvcBaseWrapper.sol";
 import {ICowSettlement} from "../../src/CowWrapper.sol";
 import {IERC4626, IBorrowing} from "euler-vault-kit/src/EVault/IEVault.sol";
 import {MockEVC} from "./mocks/MockEVC.sol";
@@ -275,8 +276,8 @@ contract CowEvcOpenPositionWrapperUnitTest is Test {
         bytes memory settleData = "";
         bytes memory remainingWrapperData = "";
 
-        vm.expectRevert(abi.encodeWithSelector(CowEvcOpenPositionWrapper.Unauthorized.selector, address(this)));
-        wrapper.evcInternalSettle(settleData, remainingWrapperData);
+        vm.expectRevert(abi.encodeWithSelector(CowEvcBaseWrapper.Unauthorized.selector, address(this)));
+        wrapper.evcInternalSettle(settleData, hex"", remainingWrapperData);
     }
 
     function test_EvcInternalSettle_RequiresCorrectCalldata() public {
@@ -290,12 +291,12 @@ contract CowEvcOpenPositionWrapperUnitTest is Test {
 
         // set incorrect expected call
         wrapper.setExpectedEvcInternalSettleCall(
-            abi.encodeCall(wrapper.evcInternalSettle, (new bytes(0), remainingWrapperData))
+            abi.encodeCall(wrapper.evcInternalSettle, (new bytes(0), new bytes(0), remainingWrapperData))
         );
 
         vm.prank(address(mockEvc));
-        vm.expectRevert(CowEvcOpenPositionWrapper.InvalidCallback.selector);
-        wrapper.evcInternalSettle(settleData, remainingWrapperData);
+        vm.expectRevert(CowEvcBaseWrapper.InvalidCallback.selector);
+        wrapper.evcInternalSettle(settleData, hex"", remainingWrapperData);
     }
 
     function test_EvcInternalSettle_CanBeCalledByEVC() public {
@@ -305,11 +306,11 @@ contract CowEvcOpenPositionWrapperUnitTest is Test {
         mockSettlement.setSuccessfulSettle(true);
 
         wrapper.setExpectedEvcInternalSettleCall(
-            abi.encodeCall(wrapper.evcInternalSettle, (settleData, remainingWrapperData))
+            abi.encodeCall(wrapper.evcInternalSettle, (settleData, hex"", remainingWrapperData))
         );
 
         vm.prank(address(mockEvc));
-        wrapper.evcInternalSettle(settleData, remainingWrapperData);
+        wrapper.evcInternalSettle(settleData, hex"", remainingWrapperData);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -366,7 +367,7 @@ contract CowEvcOpenPositionWrapperUnitTest is Test {
         vm.prank(SOLVER);
         vm.expectRevert(
             abi.encodeWithSelector(
-                CowEvcOpenPositionWrapper.OperationDeadlineExceeded.selector, params.deadline, block.timestamp
+                CowEvcBaseWrapper.OperationDeadlineExceeded.selector, params.deadline, block.timestamp
             )
         );
         wrapper.wrappedSettle(settleData, wrapperData);


### PR DESCRIPTION
## Description

A proposal to simplify the current contracts by moving repeating code across different wrappers to the same contract.

This is achieved by creating a base abstract contract `CowEvcBaseWrapper` which is supposed to be inherited by all Euler wrappers.
It aggregates code related to three main features:
- ERC712 hashing (in the form of constants, immutables, constructors and hashing)
- EVC batch execution.
- Errors.

The purpose is making it easier to spot what is different and what is the same between wrappers when reading the code.
Ideally, the remaining single-instance wrappers should have little remaining occurrences of remaining code. (One exception is `_evcInternalSettle`. I'm sure it can be simplified but I don't understand well enough the balance checks to make sure things are working after my changes, so I'm skipping it.)

The result is kind of nice imho: it makes clear(er) that what matters in the various instances is not how the batch is executed, but rather what's the content of the batches (i.e., the implementation of `_encodeSignedBatchItems`). It also makes it more visible that the settlement is executed before other operations when closing a position and after in the other two wrappers. I considered using a "itemsBefore/itemsAfter" model instead but I decided we can just switch to it if we ever find the need and just went for a flag. 

The bad part of this PR is that Solidity doesn't have generics. This means that all external accessors like `getSignedCalldata` still need to be repeated on each individual wrapper instance, causing annoying code repetition. Because of that, I also had to play with raw memory pointers, which may be dangerous to do if we abuse assembly to generate structures in memory.

Note that I tried to make the minimal changes needed to the existing code base to show the difference, so some design choices I made may be questionable. I don't expect this PR to be merged, if anything because it would make a mess in the current PR stack.

## Out of Scope

There should be no changes in the implementation, only in the code structure.

## Testing Instructions

To be fair, I didn't go in depth when building the code, I'm trusting CI to tell me if something is off.

You may also want to compare the gas cost between the two runs. Here is the diff between PR base e8e9e6cf55c5e5ecb50b16ed79545a4a88396870 and 0c9827807182bb4de71dbe7afd869e2ebc588ad4.

<details><summary>forge snapshot --diff</summary>

```
Ran 10 test suites in 336.42ms (1.07s CPU time): 124 tests passed, 0 failed, 0 skipped (124 total tests)
━ CowWrapperTest::test_integration_ThreeWrappersChained() (gas: 99125 → 99125 | 0 0.000%)
━ CowWrapperTest::test_next_CallsWrapperAndThenNextSettlement() (gas: 39431 → 39431 | 0 0.000%)
━ CowWrapperTest::test_wrappedSettle_RevertsOnInvalidSettleSelector() (gas: 18822 → 18822 | 0 0.000%)
━ CowWrapperTest::test_wrappedSettle_RevertsWithNotASolver() (gas: 20222 → 20222 | 0 0.000%)
━ CowWrapperHelpersTest::test_immutableAuthenticators() (gas: 10869 → 10869 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_EmptyArrays() (gas: 10605 → 10605 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_EmptyWrapperData() (gas: 40352 → 40352 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_MixedWrapperDataSizes() (gas: 64717 → 64717 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_MultipleWrappers() (gas: 64380 → 64380 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_RevertsOnNotAWrapper() (gas: 22855 → 22855 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_RevertsOnNotAWrapper_SecondWrapper() (gas: 29118 → 29118 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_RevertsOnSettlementContractShouldNotBeSolver() (gas: 60187 → 60187 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_RevertsOnSettlementMismatch() (gas: 667039 → 667039 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_RevertsOnWrapperDataMalformed() (gas: 24869 → 24869 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_RevertsOnWrapperDataNotFullyConsumed() (gas: 29565 → 29565 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_RevertsOnWrapperDataTooLong_FirstWrapper() (gas: 565333 → 565333 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_RevertsOnWrapperDataTooLong_SecondWrapper() (gas: 580581 → 580581 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_SingleWrapper() (gas: 34243 → 34243 | 0 0.000%)
━ CowWrapperHelpersTest::test_verifyAndBuildWrapperData_SucceedsWithMaxLengthData() (gas: 680581 → 680581 | 0 0.000%)
━ PreApprovedHashesUnitTest::testFuzz_ConsumePreApprovedHash(address,bytes32) (gas: 38101 → 38101 | 0 0.000%)
━ PreApprovedHashesUnitTest::testFuzz_MultipleUsersAndHashes(address,address,bytes32,bytes32) (gas: 69188 → 69188 | 0 0.000%)
━ PreApprovedHashesUnitTest::testFuzz_SetPreApprovedHash(address,bytes32) (gas: 27329 → 27329 | 0 0.000%)
━ PreApprovedHashesUnitTest::test_ConsumePreApprovedHash_CannotConsumedTwice() (gas: 37254 → 37254 | 0 0.000%)
━ PreApprovedHashesUnitTest::test_ConsumePreApprovedHash_EmitsEvent() (gas: 37959 → 37959 | 0 0.000%)
━ PreApprovedHashesUnitTest::test_PreApprovedHashesStorage() (gas: 51111 → 51111 | 0 0.000%)
━ PreApprovedHashesUnitTest::test_SetPreApprovedHash_CannotApproveConsumed() (gas: 38401 → 38401 | 0 0.000%)
━ PreApprovedHashesUnitTest::test_SetPreApprovedHash_CannotRevokeConsumed() (gas: 38424 → 38424 | 0 0.000%)
━ PreApprovedHashesUnitTest::test_SetPreApprovedHash_EmitsEvent() (gas: 28524 → 28524 | 0 0.000%)
━ PreApprovedHashesUnitTest::test_SetPreApprovedHash_RevokeAndReapprove() (gas: 46036 → 46036 | 0 0.000%)
━ TestablePreApprovedHashes::testConsumeHash(address,bytes32) (gas: 2611 → 2611 | 0 0.000%)
↓ CowEvcCollateralSwapWrapperUnitTest::test_Constructor_SetsImmutables() (gas: 15749 → 15748 | -1 -0.006%)
↓ CowEvcCollateralSwapWrapperUnitTest::test_ParseWrapperData_EmptySignature() (gas: 13669 → 13668 | -1 -0.007%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_DifferentVaults() (gas: 1235312 → 1235840 | 528 0.043%)
↑ CowEvcClosePositionWrapperUnitTest::test_HelperRepay_RequiresCorrectOnBehalfOfAccount() (gas: 122723 → 122797 | 74 0.060%)
↑ CowEvcClosePositionWrapperTest::test_ClosePositionWrapper_UnauthorizedInternalSettle() (gas: 13376 → 13386 | 10 0.075%)
↑ CowEvcClosePositionWrapperUnitTest::test_EvcInternalSettle_SubaccountMustBeControlledByOwner() (gas: 108564 → 108665 | 101 0.093%)
↑ CowEvcClosePositionWrapperUnitTest::test_EvcInternalSettle_OnlyEVC() (gas: 10313 → 10323 | 10 0.097%)
↑ CowEvcClosePositionWrapperUnitTest::test_Constructor_SetsDomainSeparator() (gas: 6495 → 6502 | 7 0.108%)
↓ CowEvcCollateralSwapWrapperUnitTest::test_Constructor_SetsDomainSeparator() (gas: 6487 → 6480 | -7 -0.108%)
↑ CowEvcOpenPositionWrapperUnitTest::test_Constructor_SetsDomainSeparator() (gas: 6297 → 6304 | 7 0.111%)
↑ CowEvcCollateralSwapWrapperTest::test_CollateralSwapWrapper_WithLeveragedPosition() (gas: 1257541 → 1259196 | 1655 0.132%)
↓ CowEvcCollateralSwapWrapperUnitTest::test_ParseWrapperData_LongSignature() (gas: 13681 → 13659 | -22 -0.161%)
↑ CowEvcClosePositionWrapperUnitTest::test_HelperRepay_SuccessfulRepay() (gas: 180219 → 180533 | 314 0.174%)
↑ CowEvcClosePositionWrapperUnitTest::test_HelperRepay_WithDust() (gas: 179908 → 180222 | 314 0.175%)
↑ CowEvcClosePositionWrapperUnitTest::test_HelperRepay_RepayAll() (gas: 179749 → 180064 | 315 0.175%)
↑ CowEvcClosePositionWrapperUnitTest::test_HelperRepay_PartialRepayWhenInsufficientBalance() (gas: 179708 → 180023 | 315 0.175%)
↑ CowEvcClosePositionWrapperUnitTest::test_EvcInternalSettle_RequiresCorrectCalldata() (gas: 40302 → 40378 | 76 0.189%)
↑ CowEvcClosePositionWrapperUnitTest::test_Constructor_SetsImmutables() (gas: 15806 → 15836 | 30 0.190%)
↑ CowEvcOpenPositionWrapperUnitTest::test_Constructor_SetsImmutables() (gas: 15556 → 15586 | 30 0.193%)
↑ CowEvcCollateralSwapWrapperTest::test_CollateralSwapWrapper_Subaccount() (gas: 832224 → 833879 | 1655 0.199%)
↑ CowEvcClosePositionWrapperUnitTest::test_HelperRepay_OnlyEVC() (gas: 11850 → 11876 | 26 0.219%)
↑ CowEvcCollateralSwapWrapperTest::test_CollateralSwapWrapper_MainAccount() (gas: 754466 → 756251 | 1785 0.237%)
↑ CowEvcCollateralSwapWrapperTest::test_CollateralSwapWrapper_NonSolverCannotSettle() (gas: 23877 → 23935 | 58 0.243%)
↑ CowEvcClosePositionWrapperTest::test_ClosePositionWrapper_PartialRepay() (gas: 1160452 → 1163316 | 2864 0.247%)
↑ CowEvcCollateralSwapWrapperTest::test_CollateralSwapWrapper_ThreeUsers_TwoSameOneOpposite() (gas: 3227984 → 3236108 | 8124 0.252%)
↑ CowEvcClosePositionWrapperTest::test_ClosePositionWrapper_WithPreApprovedHash() (gas: 1121302 → 1124410 | 3108 0.277%)
↑ CowEvcClosePositionWrapperTest::test_ClosePositionWrapper_SuccessFullRepay() (gas: 1150134 → 1153699 | 3565 0.310%)
↑ CowEvcOpenPositionWrapperUnitTest::test_GetSignedCalldata_EnableControllerItem() (gas: 346019 → 347147 | 1128 0.326%)
↑ CowEvcOpenPositionWrapperUnitTest::test_GetSignedCalldata_EnableCollateralItem() (gas: 345765 → 346893 | 1128 0.326%)
↑ CowEvcOpenPositionWrapperUnitTest::test_GetSignedCalldata_BorrowItem() (gas: 344090 → 345218 | 1128 0.328%)
↑ CowEvcOpenPositionWrapperUnitTest::test_GetSignedCalldata_DepositItem() (gas: 343713 → 344841 | 1128 0.328%)
↑ CowEvcOpenPositionWrapperUnitTest::test_MaxBorrowAmount() (gas: 343645 → 344773 | 1128 0.328%)
↑ CowEvcOpenPositionWrapperUnitTest::test_ZeroCollateralAmount() (gas: 343183 → 344311 | 1128 0.329%)
↓ CowEvcCollateralSwapWrapperTest::test_CollateralSwapWrapper_UnauthorizedInternalSwap() (gas: 13642 → 13597 | -45 -0.330%)
↑ CowEvcOpenPositionWrapperUnitTest::test_SameOwnerAndAccount() (gas: 339821 → 340949 | 1128 0.332%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_ParseWrapperData_WithExtraData() (gas: 18082 → 18148 | 66 0.365%)
↑ CowEvcClosePositionWrapperTest::test_ClosePositionWrapper_ThreeUsers_TwoSameOneOpposite() (gas: 2924476 → 2935336 | 10860 0.371%)
↑ CowEvcOpenPositionWrapperTest::test_OpenPositionWrapper_WithPreApprovedHash() (gas: 808296 → 811528 | 3232 0.400%)
↑ CowEvcClosePositionWrapperTest::test_ClosePositionWrapper_NonSolverCannotSettle() (gas: 23858 → 23956 | 98 0.411%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_GetSignedCalldata_EnablesNewCollateral() (gas: 115346 → 115830 | 484 0.420%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_GetSignedCalldata_UsesCorrectAccount() (gas: 109357 → 109841 | 484 0.443%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_SwapAmount_Max() (gas: 109040 → 109524 | 484 0.444%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_SwapAmount_Zero() (gas: 108444 → 108928 | 484 0.446%)
↑ CowEvcClosePositionWrapperUnitTest::test_GetSignedCalldata_RepayItem() (gas: 147780 → 148444 | 664 0.449%)
↑ CowEvcClosePositionWrapperUnitTest::test_GetSignedCalldata_PartialRepay() (gas: 143447 → 144111 | 664 0.463%)
↑ CowEvcClosePositionWrapperUnitTest::test_MaxRepayAmount() (gas: 143445 → 144109 | 664 0.463%)
↑ CowEvcClosePositionWrapperUnitTest::test_SameOwnerAndAccount() (gas: 143044 → 143708 | 664 0.464%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_WrappedSettle_OnlySolver() (gas: 16349 → 16429 | 80 0.489%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_GetApprovalHash_MatchesEIP712() (gas: 13509 → 13577 | 68 0.503%)
↑ CowEvcOpenPositionWrapperTest::test_OpenPositionWrapper_Success() (gas: 831084 → 835269 | 4185 0.504%)
↑ CowEvcClosePositionWrapperUnitTest::test_ZeroDebt() (gas: 123403 → 124067 | 664 0.538%)
↑ CowEvcOpenPositionWrapperTest::test_OpenPositionWrapper_NonSolverCannotSettle() (gas: 23338 → 23474 | 136 0.583%)
↑ CowEvcClosePositionWrapperUnitTest::test_WrappedSettle_OnlySolver() (gas: 16330 → 16428 | 98 0.600%)
↑ CowEvcOpenPositionWrapperTest::test_OpenPositionWrapper_ThreeUsers_TwoSameOneOpposite() (gas: 2120651 → 2133415 | 12764 0.602%)
↑ CowEvcClosePositionWrapperUnitTest::test_ParseWrapperData_WithExtraData() (gas: 18188 → 18298 | 110 0.605%)
↑ CowEvcClosePositionWrapperUnitTest::test_WrappedSettle_WithPreApprovedHash() (gas: 370724 → 373062 | 2338 0.631%)
↑ CowEvcClosePositionWrapperUnitTest::test_EvcInternalSettle_WithSubaccountTransfer() (gas: 145792 → 146712 | 920 0.631%)
↑ CowEvcOpenPositionWrapperTest::test_OpenPositionWrapper_SetPreApprovedHash() (gas: 39028 → 39277 | 249 0.638%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_WrappedSettle_WithPreApprovedHash() (gas: 182305 → 183499 | 1194 0.655%)
↑ CowEvcOpenPositionWrapperUnitTest::test_ParseWrapperData_WithExtraData() (gas: 13672 → 13770 | 98 0.717%)
↑ CowEvcClosePositionWrapperUnitTest::test_EvcInternalSettle_CanBeCalledByEVC() (gas: 40396 → 40701 | 305 0.755%)
↑ CowEvcCollateralSwapWrapperTest::test_CollateralSwapWrapper_ParseWrapperData() (gas: 12157 → 12249 | 92 0.757%)
↑ CowEvcClosePositionWrapperUnitTest::test_WrappedSettle_WithPermitSignature() (gas: 244682 → 246540 | 1858 0.759%)
↑ CowEvcClosePositionWrapperUnitTest::test_ParseWrapperData_EmptySignature() (gas: 13772 → 13882 | 110 0.799%)
↑ CowEvcClosePositionWrapperTest::test_ClosePositionWrapper_SetPreApprovedHash() (gas: 39086 → 39416 | 330 0.844%)
↑ CowEvcOpenPositionWrapperUnitTest::test_WrappedSettle_OnlySolver() (gas: 16095 → 16231 | 136 0.845%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_WrappedSettle_WithPermitSignature() (gas: 130701 → 131839 | 1138 0.871%)
↑ CowEvcClosePositionWrapperUnitTest::test_WrappedSettle_PreApprovedHashRevertsIfDeadlineExceeded() (gas: 137808 → 139020 | 1212 0.879%)
↑ CowEvcOpenPositionWrapperUnitTest::test_ParseWrapperData_EmptySignature() (gas: 9281 → 9379 | 98 1.056%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_WrappedSettle_BuildsCorrectBatchWithPreApproved() (gas: 108444 → 109693 | 1249 1.152%)
↑ CowEvcOpenPositionWrapperUnitTest::test_GetApprovalHash_MatchesEIP712() (gas: 8805 → 8913 | 108 1.227%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_GetApprovalHash_DifferentForDifferentParams() (gas: 17733 → 17980 | 247 1.393%)
↑ CowEvcOpenPositionWrapperTest::test_OpenPositionWrapper_ParseWrapperData() (gas: 12271 → 12462 | 191 1.557%)
↑ CowEvcClosePositionWrapperUnitTest::test_GetApprovalHash_MatchesEIP712() (gas: 13434 → 13653 | 219 1.630%)
↑ CowEvcClosePositionWrapperTest::test_ClosePositionWrapper_ParseWrapperData() (gas: 12446 → 12649 | 203 1.631%)
↑ CowEvcOpenPositionWrapperTest::test_OpenPositionWrapper_UnauthorizedInternalSettle() (gas: 13306 → 13563 | 257 1.931%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_WrappedSettle_BuildsCorrectBatchWithPermit() (gas: 58149 → 59309 | 1160 1.995%)
↑ CowEvcOpenPositionWrapperUnitTest::test_EvcInternalSettle_RequiresCorrectCalldata() (gas: 33537 → 34244 | 707 2.108%)
↑ CowEvcOpenPositionWrapperUnitTest::test_WrappedSettle_WithPreApprovedHash() (gas: 141235 → 144363 | 3128 2.215%)
↑ CowEvcCollateralSwapWrapperUnitTest::test_WrappedSettle_PreApprovedHashRevertsIfDeadlineExceeded() (gas: 86960 → 89013 | 2053 2.361%)
↑ CowEvcOpenPositionWrapperUnitTest::test_WrappedSettle_PreApprovedHashRevertsIfDeadlineExceeded() (gas: 108507 → 111228 | 2721 2.508%)
↑ CowEvcOpenPositionWrapperUnitTest::test_GetApprovalHash_DifferentForDifferentParams() (gas: 12059 → 12362 | 303 2.513%)
↑ CowEvcOpenPositionWrapperUnitTest::test_EvcInternalSettle_OnlyEVC() (gas: 9736 → 9993 | 257 2.640%)
↑ CowEvcOpenPositionWrapperUnitTest::test_EvcInternalSettle_CanBeCalledByEVC() (gas: 26013 → 26711 | 698 2.683%)
↑ CowEvcClosePositionWrapperUnitTest::test_GetApprovalHash_DifferentForDifferentParams() (gas: 17412 → 18048 | 636 3.653%)
↑ CowEvcOpenPositionWrapperUnitTest::test_WrappedSettle_WithPermitSignature() (gas: 55570 → 58475 | 2905 5.228%)

New tests:
  + CowEvcCollateralSwapWrapperUnitTest::test_EvcInternalSettle_CanBeCalledByEVC()
  + CowEvcCollateralSwapWrapperUnitTest::test_EvcInternalSettle_OnlyEVC()
  + CowEvcCollateralSwapWrapperUnitTest::test_EvcInternalSettle_RequiresCorrectCalldata()
  + CowEvcCollateralSwapWrapperUnitTest::test_EvcInternalSettle_SameOwnerAndAccount()
  + CowEvcCollateralSwapWrapperUnitTest::test_EvcInternalSettle_SubaccountMustBeControlledByOwner()
  + CowEvcCollateralSwapWrapperUnitTest::test_EvcInternalSettle_WithRemainingWrapperData()
  + CowEvcCollateralSwapWrapperUnitTest::test_EvcInternalSettle_WithSubaccount_KindBuy()
  + CowEvcCollateralSwapWrapperUnitTest::test_EvcInternalSettle_WithSubaccount_KindSell()

--------------------------------------------------------------------------------
Total tests: 116, ↑ 81, ↓ 5, ━ 30
Overall gas change: 96864 (0.348%)
```

</details>

The gas impact is visible (especially for opening a position, since it adds a function parameter to an external function) but overall limited (max ~3k gas), which I consider a reasonable tradeoff.