### PR TITLE
fixes for close position wrapper security

### DIFF
--- a/src/CowEvcClosePositionWrapper.sol
+++ b/src/CowEvcClosePositionWrapper.sol
@@ -26,6 +26,7 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
 
     error NoSwapOutput(address inboxForSwap);
     error InsufficientDebt(uint256 expectedMinDebt, uint256 actualDebt);
+    error InvalidSettlement(address collateralVault, address borrowAsset, uint256 collateralVaultTokenPrice, uint256 borrowTokenPrice);
 
     /// @dev The EIP-712 domain name used for computing the domain separator.
     bytes32 constant DOMAIN_NAME = keccak256("CowEvcClosePositionWrapper");
@@ -65,7 +66,7 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
                 borrowVault: address(0),
                 collateralVault: address(0),
                 collateralAmount: 0,
-                maxDebt: 0,
+                minRepay: 0,
                 kind: bytes32(0)
             })
         )
@@ -74,7 +75,7 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         MAX_BATCH_OPERATIONS = 2;
 
         PARAMS_TYPE_HASH = keccak256(
-            "ClosePositionParams(address owner,address account,uint256 deadline,address borrowVault,address collateralVault,uint256 collateralAmount,bytes32 kind)"
+            "ClosePositionParams(address owner,address account,uint256 deadline,address borrowVault,address collateralVault,uint256 collateralAmount,uint256 minRepay,bytes32 kind)"
         );
     }
 
@@ -97,14 +98,11 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         /// @dev The Euler vault used as collateral
         address collateralVault;
 
-        /// @dev The amount of collateral to use for the repayment. Any unused amount for the CoW swap will be returned to the account.
+        /// @dev The amount of collateral to use for the repayment. Any unused amount for the CoW swap will be returned to the account. In all cases, this should be the same as `sellAmount` in the CoW order.
         uint256 collateralAmount;
 
-        /// @dev The amount of borrow token that is being purchased in the CoW order. This is only required/used if `maxDebt` is 0 to determine 
-        uint256 borrowTokenBuyAmount;
-
-        /// @dev The maximum amount of debt that should be remaining after the operation completes. Ensure the CoW order is sufficient to repay whatever amount is needed
-        uint256 maxDebt;
+        /// @dev The min amount of debt that should be repaid from the users account after the operation completes. In all cases, this should be the same as `buyAmount` in the CoW order.
+        uint256 minRepay;
 
         /// @dev Hint on whether or not the CoW order is, either keccak256("buy") or keccak256("sell"). This will affect how much funds are sent to the owner account
         bytes32 kind;
@@ -197,14 +195,6 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         IERC20 borrowAsset = IERC20(IERC4626(params.borrowVault).asset());
         uint256 debtAmount = IBorrowing(params.borrowVault).debtOf(params.account);
 
-        require(debtAmount > params.maxDebt, InsufficientDebt(params.maxDebt, debtAmount));
-
-        uint256 repayAmount = debtAmount - params.maxDebt;
-        if (params.maxDebt == 0) {
-            // full repay: the contract expects that the user will pay 0.01% more to cover potential interest increases
-            repayAmount = debtAmount * 1.0001 ether / 1 ether;
-        }
-
         // find out exactly how much will be required
         if (params.kind == KIND_BUY) {
             uint256 collateralVaultTokenPrice;
@@ -218,17 +208,18 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
                 }
             }
 
-            require(collateralVaultTokenPrice > 0 && borrowTokenPrice > 0, "invalid settlement");
+            require(collateralVaultTokenPrice > 0 && borrowTokenPrice > 0, InvalidSettlement(params.collateralVault, address(borrowAsset), collateralVaultTokenPrice, borrowTokenPrice));
 
             // send needed collateral for the swap to the user's owner account, and the rest will go back to 
-            SafeERC20Lib.safeTransfer(IERC20(params.collateralVault), params.owner, repayAmount * borrowTokenPrice / collateralVaultTokenPrice);
-            SafeERC20Lib.safeTransfer(IERC20(params.collateralVault), params.account, IERC20(params.collateralVault).balanceOf(address(this)));
+            SafeERC20Lib.safeTransfer(IERC20(params.collateralVault), params.owner, params.minRepay * borrowTokenPrice / collateralVaultTokenPrice);
+            uint256 remainingBalance = IERC20(params.collateralVault).balanceOf(address(this));
+            if (remainingBalance > 0) {
+                SafeERC20Lib.safeTransfer(IERC20(params.collateralVault), params.account, remainingBalance);
+            }
         } else {
             // everything goes to the owners account because it will all be sold
             SafeERC20Lib.safeTransfer(IERC20(params.collateralVault), params.owner, IERC20(params.collateralVault).balanceOf(address(this)));
         }
-
-
 
         // Use CowWrapper's _internalSettle to call the settlement contract
         // wrapperData is empty since we've already processed it in _wrap
@@ -244,7 +235,7 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         }
 
         // the amount we will *actually* repay is the same as however much we get from swapping
-        repayAmount = swapResultBalance;
+        uint256 repayAmount = swapResultBalance;
 
         // we can't repay more than the available debt amount
         if (repayAmount > debtAmount) {

--- a/src/CowEvcClosePositionWrapper.sol
+++ b/src/CowEvcClosePositionWrapper.sol
@@ -23,6 +23,10 @@ import {ISignatureTransfer} from "euler-vault-kit/lib/permit2/src/interfaces/ISi
 /// If a full close is being performed, leave a small buffer for intrest accumultation, and the dust will
 /// be returned to the owner's wallet.
 contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
+
+    error NoSwapOutput(address inboxForSwap);
+    error InsufficientDebt(uint256 expectedMinDebt, uint256 actualDebt);
+
     /// @dev The EIP-712 domain name used for computing the domain separator.
     bytes32 constant DOMAIN_NAME = keccak256("CowEvcClosePositionWrapper");
 
@@ -46,7 +50,7 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         address indexed collateralVault,
         uint256 collateralAmount,
         uint256 repayAmount,
-        bytes32 kind
+        uint256 leftoverAmount
     );
 
     constructor(address _evc, ICowSettlement _settlement)
@@ -61,7 +65,7 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
                 borrowVault: address(0),
                 collateralVault: address(0),
                 collateralAmount: 0,
-                maxRepayAmount: 0,
+                maxDebt: 0,
                 kind: bytes32(0)
             })
         )
@@ -70,7 +74,7 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         MAX_BATCH_OPERATIONS = 2;
 
         PARAMS_TYPE_HASH = keccak256(
-            "ClosePositionParams(address owner,address account,uint256 deadline,address borrowVault,address collateralVault,uint256 collateralAmount,uint256 maxRepayAmount,bytes32 kind)"
+            "ClosePositionParams(address owner,address account,uint256 deadline,address borrowVault,address collateralVault,uint256 collateralAmount,bytes32 kind)"
         );
     }
 
@@ -93,16 +97,16 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         /// @dev The Euler vault used as collateral
         address collateralVault;
 
-        /// @dev The amount of collateral to swap from the collateral vault, in terms of collateral vault shares.
-        /// This should be equal to `sellAmount` on the CoW order, and
-        /// the full amount will be transferred from the wallet.
-        /// In the case of KIND_BUY order, Any excess untraded for funds will be returned to the subaccount.
+        /// @dev The amount of collateral to use for the repayment. Any unused amount for the CoW swap will be returned to the account.
         uint256 collateralAmount;
 
-        /// @dev In all cases, the maximum amount of debt to repay. For kind = KIND_BUY, this should be the same as `buyAmount` in the CoW order. For kind = KIND_SELL, this should be equal to or greater than `buyAmount`, . The actual repay amount is constrained by this value, the actual debt of the account, and the balance of the owner's wallet following the CoW trade. If the repay amount is greater than the actual debt, the full debt is repaid, and the remainder "dust" will be left in the owner account.
-        uint256 maxRepayAmount;
+        /// @dev The amount of borrow token that is being purchased in the CoW order. This is only required/used if `maxDebt` is 0 to determine 
+        uint256 borrowTokenBuyAmount;
 
-        /// @dev Whether the `collateralAmount` or `maxRepayAmount` should be considered the exact trade amount on the CoW order. Either `GPv2Order.KIND_SELL` or `GPv2Order.KIND_BUY` respectively.
+        /// @dev The maximum amount of debt that should be remaining after the operation completes. Ensure the CoW order is sufficient to repay whatever amount is needed
+        uint256 maxDebt;
+
+        /// @dev Hint on whether or not the CoW order is, either keccak256("buy") or keccak256("sell"). This will affect how much funds are sent to the owner account
         bytes32 kind;
     }
 
@@ -145,12 +149,12 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         ClosePositionParams memory params = paramsFromMemory(paramsLocation);
         items = new IEVC.BatchItem[](MAX_BATCH_OPERATIONS - 1);
 
-        // 1. Transfer collateral to the owner
+        // For the permissioned operation, transfer collateral to the owner
         items[0] = IEVC.BatchItem({
             onBehalfOfAccount: address(params.account),
             targetContract: params.collateralVault,
             value: 0,
-            data: abi.encodeCall(IERC20.transfer, (params.owner, params.collateralAmount))
+            data: abi.encodeCall(IERC20.transfer, (address(this), params.collateralAmount))
         });
 
         needsPermission = true;
@@ -166,6 +170,11 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         // Decode wrapper data into ClosePositionParams
         (ClosePositionParams memory params, bytes memory signature) = _parseClosePositionParams(wrapperData);
 
+        // Subaccounts in the EVC can be any account that shares the highest 19 bits as the owner.
+        // Here we verify that the subaccount address has been specified is, in fact, a subaccount of the owner.
+        // Otherwise its concievably possible that a transfer could happen between an owner with an unauthorized subaccount.
+        require(bytes19(bytes20(params.owner)) == bytes19(bytes20(params.account)), SubaccountMustBeControlledByOwner(params.account, params.owner));
+
         _invokeEvc(
             settleData,
             wrapperData,
@@ -175,16 +184,6 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
             params.owner,
             params.deadline
         );
-
-        emit CowEvcPositionClosed(
-            params.owner,
-            params.account,
-            params.borrowVault,
-            params.collateralVault,
-            params.collateralAmount,
-            params.maxRepayAmount,
-            params.kind
-        );
     }
 
     function _evcInternalSettle(
@@ -192,59 +191,85 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
         bytes calldata wrapperData,
         bytes calldata remainingWrapperData
     ) internal override {
-        (ClosePositionParams memory params, bytes memory signature) = _parseClosePositionParams(wrapperData);
+        (ClosePositionParams memory params,) = _parseClosePositionParams(wrapperData);
+        (address[] memory tokens,uint256[] memory prices,,) = abi.decode(settleData[4:], (address[], uint256[], ICowSettlement.Trade[], ICowSettlement.Interaction[][3]));
 
-        uint256 balanceBefore;
-        if (params.account != params.owner) {
-            // the balance before would have been the current balance without the collateral amount (which was transferred from the subaccount)
-            balanceBefore = IERC20(params.collateralVault).balanceOf(params.owner) - params.collateralAmount;
+        IERC20 borrowAsset = IERC20(IERC4626(params.borrowVault).asset());
+        uint256 debtAmount = IBorrowing(params.borrowVault).debtOf(params.account);
+
+        require(debtAmount > params.maxDebt, InsufficientDebt(params.maxDebt, debtAmount));
+
+        uint256 repayAmount = debtAmount - params.maxDebt;
+        if (params.maxDebt == 0) {
+            // full repay: the contract expects that the user will pay 0.01% more to cover potential interest increases
+            repayAmount = debtAmount * 1.0001 ether / 1 ether;
         }
+
+        // find out exactly how much will be required
+        if (params.kind == KIND_BUY) {
+            uint256 collateralVaultTokenPrice;
+            uint256 borrowTokenPrice;
+            for (uint256 i = 0;i < tokens.length;i++) {
+                if (tokens[i] == address(params.collateralVault)) {
+                    collateralVaultTokenPrice = prices[i];
+                }
+                else if (tokens[i] == address(borrowAsset)) {
+                    borrowTokenPrice = prices[i];
+                }
+            }
+
+            require(collateralVaultTokenPrice > 0 && borrowTokenPrice > 0, "invalid settlement");
+
+            // send needed collateral for the swap to the user's owner account, and the rest will go back to 
+            SafeERC20Lib.safeTransfer(IERC20(params.collateralVault), params.owner, repayAmount * borrowTokenPrice / collateralVaultTokenPrice);
+            SafeERC20Lib.safeTransfer(IERC20(params.collateralVault), params.account, IERC20(params.collateralVault).balanceOf(address(this)));
+        } else {
+            // everything goes to the owners account because it will all be sold
+            SafeERC20Lib.safeTransfer(IERC20(params.collateralVault), params.owner, IERC20(params.collateralVault).balanceOf(address(this)));
+        }
+
+
 
         // Use CowWrapper's _internalSettle to call the settlement contract
         // wrapperData is empty since we've already processed it in _wrap
         _next(settleData, remainingWrapperData);
 
-        if (params.kind == KIND_BUY && params.account != params.owner) {
-            // return any remainder to the subaccount
-            uint256 balanceAfter = IERC20(params.collateralVault).balanceOf(params.owner);
-
-            if (balanceAfter > balanceBefore) {
-                SafeERC20Lib.safeTransferFrom(
-                    IERC20(params.collateralVault),
-                    params.owner,
-                    params.account,
-                    balanceAfter - balanceBefore,
-                    address(0)
-                );
-            }
-        }
-
-        IERC20 asset = IERC20(IERC4626(params.borrowVault).asset());
-
-        uint256 debtAmount = IBorrowing(params.borrowVault).debtOf(params.account);
-
         // what is the maximum amount of debt that can
         // be repaid from the owner account?
-        uint256 repayAmount = asset.balanceOf(params.owner);
+        address inbox = _getInbox(params.account);
+        uint256 swapResultBalance = borrowAsset.balanceOf(inbox);
+
+        if (swapResultBalance == 0) {
+            revert NoSwapOutput(inbox);
+        }
+
+        // the amount we will *actually* repay is the same as however much we get from swapping
+        repayAmount = swapResultBalance;
 
         // we can't repay more than the available debt amount
         if (repayAmount > debtAmount) {
-            // the user intends to repay all their debt. we will revert if their balance is not sufficient.
+            // There will be leftover funds in the contract after repaying. Lets send that to the owner's account
+            _callInbox(inbox, address(borrowAsset), abi.encodeCall(IERC20.transfer, (params.owner, repayAmount - debtAmount)));
+
             repayAmount = debtAmount;
         }
 
-        // we also can't repay more than the user specified max repayment amount
-        if (repayAmount > params.maxRepayAmount) {
-            repayAmount = params.maxRepayAmount;
-        }
-
-        // pull funds from the user (they should have approved spending by this contract)
-        SafeERC20Lib.safeTransferFrom(asset, params.owner, address(this), repayAmount, address(0));
-
         // repay what was requested on the vault
-        safeApprove(asset, params.borrowVault, repayAmount);
-        IBorrowing(params.borrowVault).repay(repayAmount, params.account);
-        safeApprove(asset, params.borrowVault, 0);
+        // first we have to allow the vault to spend on behalf of the inbox (if we haven't already)
+        _callInbox(inbox, address(borrowAsset), abi.encodeCall(borrowAsset.approve, (params.borrowVault, repayAmount)));
+        
+        // then we actually repay by calling. It will use the funds from the Inbox account
+        _callInbox(inbox, params.borrowVault, abi.encodeCall(IBorrowing.repay, (repayAmount, params.account)));
+
+        emit CowEvcPositionClosed(
+            params.owner,
+            params.account,
+            params.borrowVault,
+            params.collateralVault,
+            params.collateralAmount,
+            repayAmount,
+            swapResultBalance - repayAmount
+        );
     }
 
     function memoryLocation(ClosePositionParams memory params) internal pure returns (ParamsLocation location) {
@@ -256,67 +281,6 @@ contract CowEvcClosePositionWrapper is CowEvcBaseWrapper {
     function paramsFromMemory(ParamsLocation location) internal pure returns (ClosePositionParams memory params) {
         assembly {
             params := location
-        }
-    }
-
-    /**
-     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
-     * on the return value: the return value is optional (but if data is returned, it must not be false).
-     * @param token The token targeted by the call.
-     * @param data The call data (encoded using abi.encode or one of its variants).
-     *
-     * This is a variant of {_callOptionalReturn} that silents catches all reverts and returns a bool instead.
-     */
-    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {
-        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
-        // we're implementing it ourselves. We cannot use {Address-functionCall} here since this should return false
-        // and not revert is the subcall reverts.
-
-        (bool success, bytes memory returndata) = address(token).call(data);
-        return success && (returndata.length == 0 || abi.decode(returndata, (bool))) && address(token).code.length > 0;
-    }
-
-    error SafeERC20FailedOperation(address);
-
-    /**
-     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
-     * on the return value: the return value is optional (but if data is returned, it must not be false).
-     * @param token The token targeted by the call.
-     * @param data The call data (encoded using abi.encode or one of its variants).
-     */
-    function _callOptionalReturn(address token, bytes memory data) private returns (bytes memory) {
-        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
-        // we're implementing it ourselves. We use {Address-functionCall} to perform this call, which verifies that
-        // the target address contains contract code and also asserts for success in the low-level call.
-
-        (bool success, bytes memory returndata) = token.call(data);
-        if (!success) {
-            revert("");
-        } else {
-            // only check if target is a contract if the call was successful and the return data is empty
-            // otherwise we already know that it was a contract
-            if (returndata.length == 0 && token.code.length == 0) {
-                revert("");
-            }
-            return returndata;
-        }
-
-        if (returndata.length != 0 && !abi.decode(returndata, (bool))) {
-            revert SafeERC20FailedOperation(address(token));
-        }
-    }
-
-    /**
-     * @dev Mostly copied from OpenZeppelin SafeERC20. Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,
-     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval
-     * to be set to zero before setting it to a non-zero value, such as USDT.
-     */
-    function safeApprove(IERC20 token, address spender, uint256 value) internal {
-        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));
-
-        if (!_callOptionalReturnBool(token, approvalCall)) {
-            _callOptionalReturn(address(token), abi.encodeCall(token.approve, (spender, 0)));
-            _callOptionalReturn(address(token), approvalCall);
         }
     }
 }

--- a/src/Inbox.sol
+++ b/src/Inbox.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8;
+
+/// @notice A contract for receiving funds from the CoW Settlement contract which can then be operated upon by a different contract in post (i.e. a wrapper)
+/// @dev The contract has two associated accounts-- the OWNER, and the BENEFICIARY. Both associated accounts have the ability to execute arbitrary calls against this contract.
+/// The purpose of the OWNER is to allow the wrapper or execute whatever operations it needs following a settlement contract operation without needing to store in the wrapper itself (ex. potentially intermingled with other user's funds) or the user's own wallet.
+/// The purpose of the BENEFICIARY is to allow the ultimate holder of the funds to be able to access this contract in the case of trouble (ex. funds got stuck, etc.)
+contract Inbox {
+    address internal immutable OWNER;
+    address internal immutable BENEFICIARY;
+
+    error Unauthorized(address);
+
+    constructor(address owner, address beneficiary) {
+        OWNER = owner;
+        BENEFICIARY = beneficiary;
+    }
+
+    /// @notice Allows the owner or beneficiary to execute an arbitrary call against this account
+    /// @dev The call structure for this function is [bytes20 -- target address][bytes data], as encoded with `abi.encodePacked`.
+    /// Also, if `value` is supplied, it will be forwarded onto the function being called.
+    fallback() external payable {
+        require(msg.sender == OWNER || msg.sender == BENEFICIARY, Unauthorized(msg.sender));
+
+        assembly {
+            // Get target address from calldata (first 20 bytes)
+            let target := shr(96, calldataload(0))
+
+            // Get data offset and length
+            // bytes calldata offset is at position 20, contains offset to actual data
+            let dataLength := sub(calldatasize(), 20)
+            calldatacopy(0, 20, sub(calldatasize(), 20))
+
+            // Execute call
+            let success := call(gas(), target, callvalue(), 0, dataLength, 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            if iszero(success) {
+                revert(0, returndatasize())
+            }
+            // Return result
+            return(0, returndatasize())
+        }
+    }
+}

--- a/test/CowEvcClosePositionWrapper.t.sol
+++ b/test/CowEvcClosePositionWrapper.t.sol
@@ -75,7 +75,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: EWETH,
             collateralVault: ESUSDS,
             collateralAmount: DEFAULT_SELL_AMOUNT,
-            maxDebt: 0,
+            minRepay: DEFAULT_BUY_AMOUNT,
             kind: GPv2Order.KIND_BUY
         });
     }
@@ -337,7 +337,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
         // Create params with custom amounts
         CowEvcClosePositionWrapper.ClosePositionParams memory params = _createDefaultParams(user, account);
         params.collateralAmount = sellAmount;
-        params.maxDebt = 0.5e18;
+        params.minRepay = 1.5e18;  // debt (2e18) - remaining (0.5e18) = 1.5e18 to repay
         params.kind = GPv2Order.KIND_SELL;
 
         // Get settlement data
@@ -624,7 +624,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: EWETH,
             collateralVault: ESUSDS,
             collateralAmount: 2550 ether,
-            maxDebt: 0,
+            minRepay: 1.001 ether,  // full repay of 1 ether debt
             kind: GPv2Order.KIND_BUY
         });
 
@@ -635,7 +635,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: EWETH,
             collateralVault: ESUSDS,
             collateralAmount: 7600 ether,
-            maxDebt: 0,
+            minRepay: 3.003 ether,  // full repay of 3 ether debt
             kind: GPv2Order.KIND_BUY
         });
 
@@ -646,7 +646,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: ESUSDS,
             collateralVault: EWETH,
             collateralAmount: 2.1 ether,
-            maxDebt: 0,
+            minRepay: 5005 ether,  // full repay of 5000 ether debt
             kind: GPv2Order.KIND_BUY
         });
 

--- a/test/CowEvcClosePositionWrapper.t.sol
+++ b/test/CowEvcClosePositionWrapper.t.sol
@@ -193,7 +193,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             buyAmount: buyAmount,
             validTo: validTo,
             owner: owner,
-            receiver: closePositionWrapper.getInbox(account),
+            receiver: closePositionWrapper.getInbox(user, account),
             isBuy: true
         });
 
@@ -337,7 +337,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
         // Create params with custom amounts
         CowEvcClosePositionWrapper.ClosePositionParams memory params = _createDefaultParams(user, account);
         params.collateralAmount = sellAmount;
-        params.minRepay = 1.5e18;  // debt (2e18) - remaining (0.5e18) = 1.5e18 to repay
+        params.minRepay = 1.5e18; // debt (2e18) - remaining (0.5e18) = 1.5e18 to repay
         params.kind = GPv2Order.KIND_SELL;
 
         // Get settlement data
@@ -624,7 +624,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: EWETH,
             collateralVault: ESUSDS,
             collateralAmount: 2550 ether,
-            minRepay: 1.001 ether,  // full repay of 1 ether debt
+            minRepay: 1.001 ether, // full repay of 1 ether debt
             kind: GPv2Order.KIND_BUY
         });
 
@@ -635,7 +635,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: EWETH,
             collateralVault: ESUSDS,
             collateralAmount: 7600 ether,
-            minRepay: 3.003 ether,  // full repay of 3 ether debt
+            minRepay: 3.003 ether, // full repay of 3 ether debt
             kind: GPv2Order.KIND_BUY
         });
 
@@ -646,7 +646,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: ESUSDS,
             collateralVault: EWETH,
             collateralAmount: 2.1 ether,
-            minRepay: 5005 ether,  // full repay of 5000 ether debt
+            minRepay: 5005 ether, // full repay of 5000 ether debt
             kind: GPv2Order.KIND_BUY
         });
 
@@ -679,7 +679,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             buyAmount: 1.001 ether,
             validTo: validTo,
             owner: user,
-            receiver: closePositionWrapper.getInbox(account1),
+            receiver: closePositionWrapper.getInbox(user, account1),
             isBuy: true
         });
         (trades[1],,) = setupCowOrder({
@@ -690,7 +690,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             buyAmount: 3.003 ether,
             validTo: validTo,
             owner: user2,
-            receiver: closePositionWrapper.getInbox(account2),
+            receiver: closePositionWrapper.getInbox(user2, account2),
             isBuy: true
         });
         (trades[2],,) = setupCowOrder({
@@ -701,7 +701,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             buyAmount: 5005 ether,
             validTo: validTo,
             owner: user3,
-            receiver: closePositionWrapper.getInbox(account3),
+            receiver: closePositionWrapper.getInbox(user3, account3),
             isBuy: true
         });
 
@@ -712,9 +712,8 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
         interactions[2] = new ICowSettlement.Interaction[](0);
 
         // We pull the money out of the euler vaults
-        interactions[1][0] = getWithdrawInteraction(
-            ESUSDS, (1.001 ether + 3.003 ether) * clearingPrices[1] / clearingPrices[0]
-        );
+        interactions[1][0] =
+            getWithdrawInteraction(ESUSDS, (1.001 ether + 3.003 ether) * clearingPrices[1] / clearingPrices[0]);
         interactions[1][1] = getWithdrawInteraction(EWETH, 5005 ether * clearingPrices[0] / clearingPrices[1]);
 
         // We swap. We only need to swap the difference of the 3 closes (since coincidence of wants)

--- a/test/CowEvcClosePositionWrapper.t.sol
+++ b/test/CowEvcClosePositionWrapper.t.sol
@@ -146,6 +146,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
         uint256 userPrivateKey
     ) internal returns (bytes memory) {
         ecdsa.setPrivateKey(userPrivateKey);
+        // NOTE: this permit signature differs from the other wrappers as we are signing *WITH THE SUBACCOUNT*
         return ecdsa.signPermit(
             params.owner,
             address(closePositionWrapper),

--- a/test/CowEvcClosePositionWrapper.t.sol
+++ b/test/CowEvcClosePositionWrapper.t.sol
@@ -71,7 +71,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: EWETH,
             collateralVault: ESUSDS,
             collateralAmount: DEFAULT_SELL_AMOUNT,
-            repayAmount: DEFAULT_BUY_AMOUNT,
+            maxRepayAmount: DEFAULT_BUY_AMOUNT,
             kind: GPv2Order.KIND_BUY
         });
     }
@@ -267,7 +267,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             params.borrowVault,
             params.collateralVault,
             params.collateralAmount,
-            params.repayAmount,
+            params.maxRepayAmount,
             params.kind
         );
 
@@ -332,7 +332,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
         // Create params with custom amounts and KIND_SELL
         CowEvcClosePositionWrapper.ClosePositionParams memory params = _createDefaultParams(user, account);
         params.collateralAmount = sellAmount;
-        params.repayAmount = buyAmount;
+        params.maxRepayAmount = buyAmount;
         params.kind = GPv2Order.KIND_SELL;
 
         // Get settlement data
@@ -368,7 +368,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             params.borrowVault,
             params.collateralVault,
             params.collateralAmount,
-            params.repayAmount,
+            params.maxRepayAmount,
             params.kind
         );
 
@@ -386,7 +386,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
         address account = address(uint160(user) ^ uint8(0x01));
         CowEvcClosePositionWrapper.ClosePositionParams memory params = _createDefaultParams(user, account);
         params.collateralAmount = 0;
-        params.repayAmount = type(uint256).max;
+        params.maxRepayAmount = type(uint256).max;
 
         bytes memory wrapperData = abi.encode(params, new bytes(65));
 
@@ -401,7 +401,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
         address account = address(uint160(user) ^ uint8(0x01));
         CowEvcClosePositionWrapper.ClosePositionParams memory params = _createDefaultParams(user, account);
         params.collateralAmount = 0;
-        params.repayAmount = type(uint256).max;
+        params.maxRepayAmount = type(uint256).max;
 
         bytes32 hash = closePositionWrapper.getApprovalHash(params);
 
@@ -487,7 +487,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             params.borrowVault,
             params.collateralVault,
             params.collateralAmount,
-            params.repayAmount,
+            params.maxRepayAmount,
             params.kind
         );
 
@@ -621,7 +621,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: EWETH,
             collateralVault: ESUSDS,
             collateralAmount: 2550 ether,
-            repayAmount: 1.001 ether,
+            maxRepayAmount: 1.001 ether,
             kind: GPv2Order.KIND_BUY
         });
 
@@ -632,7 +632,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: EWETH,
             collateralVault: ESUSDS,
             collateralAmount: 7600 ether,
-            repayAmount: 3.003 ether,
+            maxRepayAmount: 3.003 ether,
             kind: GPv2Order.KIND_BUY
         });
 
@@ -643,7 +643,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             borrowVault: ESUSDS,
             collateralVault: EWETH,
             collateralAmount: 2.1 ether,
-            repayAmount: 5005 ether,
+            maxRepayAmount: 5005 ether,
             kind: GPv2Order.KIND_BUY
         });
 
@@ -673,7 +673,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             sellTokenIndex: 2,
             buyTokenIndex: 1,
             sellAmount: params1.collateralAmount,
-            buyAmount: params1.repayAmount,
+            buyAmount: params1.maxRepayAmount,
             validTo: validTo,
             owner: user,
             receiver: user,
@@ -684,7 +684,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             sellTokenIndex: 2,
             buyTokenIndex: 1,
             sellAmount: params2.collateralAmount,
-            buyAmount: params2.repayAmount,
+            buyAmount: params2.maxRepayAmount,
             validTo: validTo,
             owner: user2,
             receiver: user2,
@@ -695,7 +695,7 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
             sellTokenIndex: 3,
             buyTokenIndex: 0,
             sellAmount: params3.collateralAmount,
-            buyAmount: params3.repayAmount,
+            buyAmount: params3.maxRepayAmount,
             validTo: validTo,
             owner: user3,
             receiver: user3,
@@ -710,9 +710,9 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
 
         // We pull the money out of the euler vaults
         interactions[1][0] = getWithdrawInteraction(
-            ESUSDS, (params1.repayAmount + params2.repayAmount) * clearingPrices[1] / clearingPrices[0]
+            ESUSDS, (params1.maxRepayAmount + params2.maxRepayAmount) * clearingPrices[1] / clearingPrices[0]
         );
-        interactions[1][1] = getWithdrawInteraction(EWETH, params3.repayAmount * clearingPrices[0] / clearingPrices[1]);
+        interactions[1][1] = getWithdrawInteraction(EWETH, params3.maxRepayAmount * clearingPrices[0] / clearingPrices[1]);
 
         // We swap. We only need to swap the difference of the 3 closes (since coincidence of wants)
         // It comes out to 5000 SUSDS needs to become WETH
@@ -744,161 +744,5 @@ contract CowEvcClosePositionWrapperTest is CowBaseTest {
         assertEq(IEVault(EWETH).debtOf(account1), 0, "User1 should have no WETH debt after closing");
         assertEq(IEVault(EWETH).debtOf(account2), 0, "User2 should have no WETH debt after closing");
         assertEq(IEVault(ESUSDS).debtOf(account3), 0, "User3 should have no SUSDS debt after closing");
-    }
-
-    /// @notice Test that a malicious solver cannot use a postInteraction with EVC.permit to pull funds from an unauthorized user
-    /// @dev Verifies that even with an attacker's permit signature, calling helperRepay with a different owner fails
-    function test_ClosePositionWrapper_PostInteractionWithPermitUnauthorizedOwner() external {
-        vm.skip(bytes(forkRpcUrl).length == 0);
-
-        uint256 borrowAmount = 1e18;
-        uint256 collateralAmount = SUSDS_MARGIN + 2495e18;
-
-        address account = address(uint160(user) ^ uint8(0x01));
-        address attacker = user2;
-        address attackerAccount = address(uint160(attacker) ^ uint8(0x01));
-
-        vm.label(user, "Victim");
-        vm.label(account, "Victim Account");
-        vm.label(attackerAccount, "Attacker Account");
-        vm.label(attacker, "Attacker");
-
-        // Setup a leveraged position for user (legit position)
-        setupLeveragedPositionFor({
-            owner: user,
-            account: account,
-            collateralVault: ESUSDS,
-            borrowVault: EWETH,
-            collateralAmount: collateralAmount,
-            borrowAmount: borrowAmount
-        });
-
-        // Setup a leveraged position for the attacker
-        uint256 attackerBorrowAmount = 1e18;
-        uint256 attackerCollateralAmount = SUSDS_MARGIN + 2495e18;
-        setupLeveragedPositionFor({
-            owner: attacker,
-            account: attackerAccount,
-            collateralVault: ESUSDS,
-            borrowVault: EWETH,
-            collateralAmount: attackerCollateralAmount,
-            borrowAmount: attackerBorrowAmount
-        });
-
-        // Create normal close params for legitimate user
-        CowEvcClosePositionWrapper.ClosePositionParams memory params = _createDefaultParams(attacker, attackerAccount);
-
-        // Get settlement data for the legitimate position close
-        SettlementData memory settlement = getClosePositionSettlement({
-            owner: attacker,
-            receiver: attacker,
-            sellVaultToken: ESUSDS,
-            buyToRepayToken: WETH,
-            sellAmount: attackerCollateralAmount / 2,
-            buyAmount: attackerBorrowAmount / 2
-        });
-
-        // Setup normal approvals for user who is preparing to close their position
-        _setupClosePositionApprovalsFor(user, account, ESUSDS, WETH);
-
-        // Setup approvals for the attacker
-        _setupClosePositionApprovalsFor(attacker, attackerAccount, ESUSDS, WETH);
-
-        // Give the attacker extra WETH
-        deal(WETH, attacker, 10e18);
-        deal(ESUSDS, attacker, 10e18);
-
-        // Create permit signature from user
-        bytes memory permitSignature = _createPermitSignatureFor(params, privateKey);
-
-        // The attacker (as a malicious solver) tries to craft a postInteraction
-        // that uses EVC.permit to authorize calling helperRepay with the attacker's account
-        // instead of the legitimate user's account. This would attempt to pull funds from
-        // the attacker's account without proper authorization context.
-
-        // Create the malicious call to helperRepay with attacker's account
-        IEVC.BatchItem[] memory maliciousBatch = new IEVC.BatchItem[](1);
-        maliciousBatch[0] = IEVC.BatchItem({
-            onBehalfOfAccount: attackerAccount,
-            targetContract: address(closePositionWrapper),
-            value: 0,
-            data: abi.encodeCall(closePositionWrapper.helperRepay, (EWETH, user, attackerAccount))
-        });
-
-        vm.expectRevert(
-            abi.encodeWithSelector(CowEvcBaseWrapper.SubaccountMustBeControlledByOwner.selector, attackerAccount, user)
-        );
-        vm.prank(attacker);
-        EVC.batch(maliciousBatch);
-
-        //bytes memory maliciousBatchCall = abi.encodeCall(EVC.batch, (maliciousBatch));
-
-        // Create an EVC.permit call signed by the attacker
-        // This permit would authorize the wrapper to call itself with the attacker's parameters
-        ecdsa.setPrivateKey(privateKey2); // Use attacker's private key
-        /*bytes memory permitSignatureFromAttacker = ecdsa.signPermit(
-            attacker, // signer
-            address(COW_SETTLEMENT), // sender (the attacker is authorizing this)
-            uint256(uint160(address(closePositionWrapper))), // nonceNamespace
-            1, // nonce
-            block.timestamp + 1 hours, // deadline
-            0, // value
-            maliciousBatchCall // data
-        );
-
-        vm.expectRevert();
-        EVC.permit(
-            attacker, // signer
-            address(COW_SETTLEMENT), // sender
-            uint256(uint160(address(closePositionWrapper))), // nonceNamespace
-            1, // nonce (+1 because we already consumed the first nonce)
-            block.timestamp + 1 hours, // deadline
-            0, // value
-            maliciousBatchCall, // data
-            permitSignatureFromAttacker // signature
-        );*/
-
-        // Create the postInteraction that calls EVC.permit
-        /*ICowSettlement.Interaction memory maliciousPostInteraction = ICowSettlement.Interaction({
-            target: address(EVC),
-            value: 0,
-            callData: abi.encodeCall(
-                EVC.permit,
-                (
-                    attacker, // signer
-                    address(COW_SETTLEMENT), // sender
-                    uint256(uint160(address(closePositionWrapper))), // nonceNamespace
-                    1, // nonce (+1 because we already consumed the first nonce)
-                    block.timestamp + 1 hours, // deadline
-                    0, // value
-                    maliciousBatchCall, // data
-                    permitSignatureFromAttacker // signature
-                )
-            )
-        });
-
-        // Create modified interactions with the malicious postInteraction
-        ICowSettlement.Interaction[][3] memory modifiedInteractions;
-        modifiedInteractions[0] = settlement.interactions[0]; // preInteractions (empty)
-        modifiedInteractions[1] = settlement.interactions[1]; // intraInteractions
-        modifiedInteractions[2] = new ICowSettlement.Interaction[](1);
-        modifiedInteractions[2][0] = maliciousPostInteraction;
-
-        // Re-encode settlement data with modified interactions containing the malicious permit
-        bytes memory maliciousSettleData = abi.encodeCall(
-            ICowSettlement.settle,
-            (settlement.tokens, settlement.clearingPrices, settlement.trades, modifiedInteractions)
-        );
-
-        bytes memory wrapperData = encodeWrapperData(abi.encode(params, permitSignature));
-
-        // The transaction should revert because even though the attacker has signed a permit,
-        // the helperRepay function tries to pull funds from the attacker's account.
-        // The function checks that onBehalfOfAccount matches the account parameter,
-        // but since this is being called in a postInteraction context, the EVC batch
-        // is still operating on behalf of the original account, not the attacker.
-        // This causes an authorization mismatch or transfer failure.
-        vm.expectRevert();
-        CowWrapper(address(closePositionWrapper)).wrappedSettle(maliciousSettleData, wrapperData);*/
     }
 }

--- a/test/unit/CowEvcClosePositionWrapper.unit.t.sol
+++ b/test/unit/CowEvcClosePositionWrapper.unit.t.sol
@@ -50,7 +50,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
             borrowVault: address(mockBorrowVault),
             collateralVault: address(mockCollateralVault),
             collateralAmount: 0,
-            repayAmount: DEFAULT_REPAY_AMOUNT,
+            maxRepayAmount: DEFAULT_REPAY_AMOUNT,
             kind: KIND_BUY
         });
     }
@@ -193,9 +193,9 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         CowEvcClosePositionWrapper.ClosePositionParams memory params2 = _getDefaultParams();
         params2.owner = ACCOUNT;
 
-        // Change repayAmount field
+        // Change maxRepayAmount field
         CowEvcClosePositionWrapper.ClosePositionParams memory params3 = _getDefaultParams();
-        params3.repayAmount = 2000e18;
+        params3.maxRepayAmount = 2000e18;
 
         bytes32 hash1 = wrapper.getApprovalHash(params1);
         bytes32 hash2 = wrapper.getApprovalHash(params2);
@@ -213,7 +213,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         mockBorrowVault.setDebt(ACCOUNT, DEFAULT_REPAY_AMOUNT);
 
         CowEvcClosePositionWrapper.ClosePositionParams memory params = _getDefaultParams();
-        params.repayAmount = 500e18; // Less than debt
+        params.maxRepayAmount = 500e18; // Less than debt
 
         bytes memory signedCalldata = wrapper.encodePermitData(params);
         IEVC.BatchItem[] memory items = _decodeSignedCalldata(signedCalldata);
@@ -221,7 +221,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         assertEq(items.length, 1, "Should have 1 batch item for partial repay");
     }
 
-    function test_GetSignedCalldata_RepayItem() public {
+    /*function test_GetSignedCalldata_RepayItem() public {
         mockBorrowVault.setDebt(ACCOUNT, DEFAULT_REPAY_AMOUNT);
 
         CowEvcClosePositionWrapper.ClosePositionParams memory params = _getDefaultParams();
@@ -236,13 +236,13 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
             abi.encodeCall(wrapper.helperRepay, (address(mockBorrowVault), OWNER, ACCOUNT)),
             "Should call helperRepay"
         );
-    }
+    }*/
 
     /*//////////////////////////////////////////////////////////////
                     HELPER REPAY TESTS
     //////////////////////////////////////////////////////////////*/
 
-    function test_HelperRepay_SuccessfulRepay() public {
+    /*function test_HelperRepay_SuccessfulRepay() public {
         // Give owner some tokens (not wrapper)
         mockAsset.mint(OWNER, 1000e18);
 
@@ -389,7 +389,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         vm.prank(address(mockEvc));
         vm.expectRevert(abi.encodeWithSelector(CowEvcBaseWrapper.Unauthorized.selector, wrongAccount));
         mockEvc.batch(items);
-    }
+    }*/
 
     /*//////////////////////////////////////////////////////////////
                     EVC INTERNAL SETTLE TESTS
@@ -454,7 +454,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
             borrowVault: address(mockBorrowVault),
             collateralVault: address(mockCollateralVault),
             collateralAmount: 1000e18,
-            repayAmount: 1000e18,
+            maxRepayAmount: 1000e18,
             kind: hex"6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc" // KIND_BUY
         });
 
@@ -526,7 +526,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
             borrowVault: address(mockBorrowVault),
             collateralVault: address(mockCollateralVault),
             collateralAmount: 1000e18,
-            repayAmount: 1000e18,
+            maxRepayAmount: 1000e18,
             kind: hex"6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc" // KIND_BUY
         });
 
@@ -611,7 +611,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
             borrowVault: address(mockBorrowVault),
             collateralVault: address(mockCollateralVault),
             collateralAmount: 0,
-            repayAmount: 1000e18,
+            maxRepayAmount: 1000e18,
             kind: hex"6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc" // KIND_BUY
         });
 
@@ -786,7 +786,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         mockBorrowVault.setDebt(ACCOUNT, DEFAULT_REPAY_AMOUNT);
 
         CowEvcClosePositionWrapper.ClosePositionParams memory params = _getDefaultParams();
-        params.repayAmount = type(uint256).max;
+        params.maxRepayAmount = type(uint256).max;
 
         bytes memory signedCalldata = wrapper.encodePermitData(params);
         IEVC.BatchItem[] memory items = _decodeSignedCalldata(signedCalldata);

--- a/test/unit/CowEvcClosePositionWrapper.unit.t.sol
+++ b/test/unit/CowEvcClosePositionWrapper.unit.t.sol
@@ -229,159 +229,6 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
     }
 
     /*//////////////////////////////////////////////////////////////
-                    HELPER REPAY TESTS
-    //////////////////////////////////////////////////////////////*/
-
-    /*function test_HelperRepay_SuccessfulRepay() public {
-        // Give owner some tokens (not wrapper)
-        mockAsset.mint(OWNER, 1000e18);
-
-        // Owner must approve wrapper to spend their tokens
-        vm.prank(OWNER);
-        mockAsset.approve(address(wrapper), 1000e18);
-
-        // Set up borrow vault with debt
-        mockBorrowVault.setDebt(ACCOUNT, 1000e18);
-        mockBorrowVault.setRepayAmount(1000e18);
-
-        // Set the correct onBehalfOfAccount for authentication check
-        mockEvc.setOnBehalfOf(ACCOUNT);
-
-        // Call through EVC batch
-        IEVC.BatchItem[] memory items = new IEVC.BatchItem[](1);
-        items[0] = IEVC.BatchItem({
-            onBehalfOfAccount: ACCOUNT,
-            targetContract: address(wrapper),
-            value: 0,
-            data: abi.encodeCall(wrapper.helperRepay, (address(mockBorrowVault), OWNER, ACCOUNT))
-        });
-
-        vm.prank(address(mockEvc));
-        mockEvc.batch(items);
-
-        // Verify owner's tokens were used for repayment
-        assertEq(mockAsset.balanceOf(OWNER), 0, "Owner should have no tokens left");
-    }
-
-    function test_HelperRepay_WithDust() public {
-        // Give owner more tokens than needed for repay
-        mockAsset.mint(OWNER, 1100e18);
-
-        // Owner must approve wrapper to spend their tokens
-        vm.prank(OWNER);
-        mockAsset.approve(address(wrapper), 1100e18);
-
-        // Set up borrow vault with debt
-        mockBorrowVault.setDebt(ACCOUNT, 1000e18);
-        mockBorrowVault.setRepayAmount(1000e18); // Only 1000 actually needed
-
-        // Set the correct onBehalfOfAccount for authentication check
-        mockEvc.setOnBehalfOf(ACCOUNT);
-
-        IEVC.BatchItem[] memory items = new IEVC.BatchItem[](1);
-        items[0] = IEVC.BatchItem({
-            onBehalfOfAccount: ACCOUNT,
-            targetContract: address(wrapper),
-            value: 0,
-            data: abi.encodeCall(wrapper.helperRepay, (address(mockBorrowVault), OWNER, ACCOUNT))
-        });
-
-        vm.prank(address(mockEvc));
-        mockEvc.batch(items);
-
-        // Owner should have 100 tokens left (1100 - 1000 repaid)
-        assertEq(mockAsset.balanceOf(OWNER), 100e18, "Owner should have dust remaining");
-    }
-
-    function test_HelperRepay_PartialRepayWhenInsufficientBalance() public {
-        // Give owner insufficient tokens to fully repay debt
-        mockAsset.mint(OWNER, 500e18);
-
-        // Owner must approve wrapper to spend their tokens
-        vm.prank(OWNER);
-        mockAsset.approve(address(wrapper), 500e18);
-
-        mockBorrowVault.setDebt(ACCOUNT, 1000e18);
-        mockBorrowVault.setRepayAmount(500e18); // Will only repay what's available
-
-        // Set the correct onBehalfOfAccount for authentication check
-        mockEvc.setOnBehalfOf(ACCOUNT);
-
-        IEVC.BatchItem[] memory items = new IEVC.BatchItem[](1);
-        items[0] = IEVC.BatchItem({
-            onBehalfOfAccount: ACCOUNT,
-            targetContract: address(wrapper),
-            value: 0,
-            data: abi.encodeCall(wrapper.helperRepay, (address(mockBorrowVault), OWNER, ACCOUNT))
-        });
-
-        vm.prank(address(mockEvc));
-        mockEvc.batch(items);
-
-        // Should repay partial amount (500e18)
-        assertEq(mockAsset.balanceOf(OWNER), 0, "Owner should have no tokens left");
-    }
-
-    function test_HelperRepay_RepayAll() public {
-        mockAsset.mint(OWNER, 1100e18);
-
-        // Owner must approve wrapper to spend their tokens
-        vm.prank(OWNER);
-        mockAsset.approve(address(wrapper), 1100e18);
-
-        mockBorrowVault.setDebt(ACCOUNT, 1000e18);
-        mockBorrowVault.setRepayAmount(1000e18);
-
-        // Set the correct onBehalfOfAccount for authentication check
-        mockEvc.setOnBehalfOf(ACCOUNT);
-
-        IEVC.BatchItem[] memory items = new IEVC.BatchItem[](1);
-        items[0] = IEVC.BatchItem({
-            onBehalfOfAccount: ACCOUNT,
-            targetContract: address(wrapper),
-            value: 0,
-            data: abi.encodeCall(wrapper.helperRepay, (address(mockBorrowVault), OWNER, ACCOUNT))
-        });
-
-        vm.prank(address(mockEvc));
-        mockEvc.batch(items);
-
-        // Dust should remain with owner (100e18)
-        assertEq(mockAsset.balanceOf(OWNER), 100e18, "Owner should have dust remaining");
-    }
-
-    function test_HelperRepay_OnlyEVC() public {
-        vm.expectRevert(abi.encodeWithSelector(CowEvcBaseWrapper.Unauthorized.selector, address(this)));
-        wrapper.helperRepay(address(mockBorrowVault), OWNER, ACCOUNT);
-    }
-
-    function test_HelperRepay_RequiresCorrectOnBehalfOfAccount() public {
-        mockAsset.mint(OWNER, 1000e18);
-
-        vm.prank(OWNER);
-        mockAsset.approve(address(wrapper), 1000e18);
-
-        mockBorrowVault.setDebt(ACCOUNT, 1000e18);
-
-        // Create a batch item that specifies ACCOUNT but the helperRepay expects a different account
-        IEVC.BatchItem[] memory items = new IEVC.BatchItem[](1);
-        address wrongAccount = address(0x9999);
-        items[0] = IEVC.BatchItem({
-            onBehalfOfAccount: wrongAccount, // This will be set as getCurrentOnBehalfOfAccount
-            targetContract: address(wrapper),
-            value: 0,
-            data: abi.encodeCall(
-                wrapper.helperRepay,
-                (address(mockBorrowVault), OWNER, ACCOUNT) // But we're trying to repay for ACCOUNT
-            )
-        });
-
-        vm.prank(address(mockEvc));
-        vm.expectRevert(abi.encodeWithSelector(CowEvcBaseWrapper.Unauthorized.selector, wrongAccount));
-        mockEvc.batch(items);
-    }*/
-
-    /*//////////////////////////////////////////////////////////////
                     EVC INTERNAL SETTLE TESTS
     //////////////////////////////////////////////////////////////*/
 
@@ -431,7 +278,11 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
             abi.encodeCall(wrapper.evcInternalSettle, (settleData, wrapperData, remainingWrapperData))
         );
 
-        vm.expectRevert(abi.encodeWithSelector(CowEvcClosePositionWrapper.NoSwapOutput.selector, wrapper.getInbox(params.account)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CowEvcClosePositionWrapper.NoSwapOutput.selector, wrapper.getInbox(params.owner, params.account)
+            )
+        );
         vm.prank(address(mockEvc));
         wrapper.evcInternalSettle(settleData, wrapperData, remainingWrapperData);
     }
@@ -465,9 +316,13 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         );
 
         // put funds in the inbox so it doesn't revert
-        deal(address(mockDebtAsset), wrapper.getInbox(params.account), 1);
+        deal(address(mockDebtAsset), wrapper.getInbox(params.owner, params.account), 1);
 
-        vm.expectRevert(abi.encodeWithSelector(CowEvcClosePositionWrapper.InvalidSettlement.selector, mockCollateralVault, mockDebtAsset, 0, 0));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CowEvcClosePositionWrapper.InvalidSettlement.selector, mockCollateralVault, mockDebtAsset, 0, 0
+            )
+        );
         vm.prank(address(mockEvc));
         wrapper.evcInternalSettle(settleData, wrapperData, remainingWrapperData);
     }
@@ -487,7 +342,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         );
 
         // put funds in the inbox so it doesn't revert
-        deal(address(mockDebtAsset), wrapper.getInbox(params.account), 1);
+        deal(address(mockDebtAsset), wrapper.getInbox(params.owner, params.account), 1);
 
         vm.prank(address(mockEvc));
         wrapper.evcInternalSettle(settleData, wrapperData, remainingWrapperData);
@@ -541,7 +396,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         );
 
         // put funds in the inbox so it doesn't revert
-        deal(address(mockDebtAsset), wrapper.getInbox(params.account), 1);
+        deal(address(mockDebtAsset), wrapper.getInbox(params.owner, params.account), 1);
 
         vm.prank(address(mockEvc));
         wrapper.evcInternalSettle(settleData, wrapperData, remainingWrapperData);
@@ -552,11 +407,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
             2000e18,
             "Owner should only have the amount required to complete the trade"
         );
-        assertEq(
-            mockCollateralVault.balanceOf(ACCOUNT),
-            3000e18,
-            "Account should have any extra returned to it"
-        );
+        assertEq(mockCollateralVault.balanceOf(ACCOUNT), 3000e18, "Account should have any extra returned to it");
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -654,7 +505,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         mockEvc.setSuccessfulBatch(true);
 
         // put funds in the inbox so it doesn't revert
-        deal(address(mockDebtAsset), wrapper.getInbox(params.account), 1);
+        deal(address(mockDebtAsset), wrapper.getInbox(params.owner, params.account), 1);
 
         vm.prank(SOLVER);
         wrapper.wrappedSettle(settleData, wrapperData);
@@ -685,7 +536,7 @@ contract CowEvcClosePositionWrapperUnitTest is Test {
         mockEvc.setSuccessfulBatch(true);
 
         // put funds in the inbox so it doesn't revert
-        deal(address(mockDebtAsset), wrapper.getInbox(params.account), 1);
+        deal(address(mockDebtAsset), wrapper.getInbox(params.owner, params.account), 1);
 
         vm.prank(SOLVER);
         wrapper.wrappedSettle(settleData, wrapperData);


### PR DESCRIPTION
## Description
Fixes for close position wrappers security.

## Context

This is just an intermediate PR to try and fix some issues identified with the overall design of the close position wrapper. The design choices here will be applied to the other wrappers as well.

* added `Inbox` as a way to receive assets coming out of the setltement contract. Implementors will need to make sure their `receiver` is set appropriately, toherwise the wrapper will fail to work as intended/revert
* remove the `helperRepay` function
* Change what was previously the helperRepay function into a signed permit that pulls funds from the user's subaccount
* move the subaccount match check to the beginning since its so fundamental

## Out of Scope
This is just an immediate

## Testing Instructions
Provide clear, step-by-step instructions for verifying this change locally.  
Assume the reviewer has no prior context about your setup.

This section reinforces the scope of the PR by outlining what should be tested and what the expected outcomes are.
