### PR TITLE
 update deployment 1.1.0

### DIFF
--- a/cannonfile.toml
+++ b/cannonfile.toml
@@ -4,7 +4,7 @@
 # https://usecannon.com/learn/cannonfile
 
 name = "cow-euler-integration"
-version = "1.0.0"
+version = "1.1.0"
 
 # Set the package reference for the settlement contract. [var.pkg]
 [var.pkg]
@@ -23,7 +23,8 @@ source = "<%= settings.evcPkg %>"
 chainId = 13370
 
 [var.main]
-salt = "0x0000000000000000000000000000000000000000000000000000000000000000"
+salt = "<%= HashZero %>"
+wrapperHelpersSalt = "<%= HashZero %>"
 cowSettlementAddress = "<%= cow.Settlement.address %>"
 
 # When deploying, override this setting with the correct EVC address from https://evc.wtf/docs/contracts/deployment-addresses
@@ -49,6 +50,14 @@ create2 = true
 ifExists = "continue"
 salt = "<%= settings.salt %>"
 args = ["<%= settings.evcAddress %>", "<%= settings.cowSettlementAddress %>"]
+
+# We also include the CowWrapperHelper as we don't have a better other place to deploy it right now.
+[deploy.WrapperHelpers]
+artifact = "CowWrapperHelpers"
+create2 = true
+ifExists = "continue"
+salt = "<%= settings.wrapperHelpersSalt %>"
+args = ["<%= settings.cowSettlementAddress %>"]
 
 # Authorise these wrappers as a solvers
 [invoke.authorizeOpenWrapper]

--- a/cannonfile.toml
+++ b/cannonfile.toml
@@ -57,7 +57,7 @@ artifact = "CowWrapperHelpers"
 create2 = true
 ifExists = "continue"
 salt = "<%= settings.wrapperHelpersSalt %>"
-args = ["<%= settings.cowSettlementAddress %>"]
+args = ["<%= cow.Authenticator.address %>"]
 
 # Authorise these wrappers as a solvers
 [invoke.authorizeOpenWrapper]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "license": "ISC",
   "packageManager": "pnpm@10.28.0",
   "devDependencies": {
-    "@usecannon/cli": "^2.26.0-alpha.0"
+    "@usecannon/cli": "^2.26.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@usecannon/cli':
-        specifier: ^2.26.0-alpha.0
-        version: 2.26.0-alpha.0
+        specifier: ^2.26.0
+        version: 2.26.0
 
 packages:
 
@@ -164,12 +164,12 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
-  '@usecannon/builder@2.26.0-alpha.0':
-    resolution: {integrity: sha512-o1YUNWb6WxcKU/byMbzHfGvzYn795YQEp2aJ+dgcqidNd3p5T3cX0Q86QeDEPGoCaJgqPmACN21/iE3NvyTWhA==}
+  '@usecannon/builder@2.26.0':
+    resolution: {integrity: sha512-rzgp+CInwn9TQNaQPYUVJWly0WTeFmkxu+/nC3DoQIY+lW4bL2bDENMNwfN+aIHIUf59Yb7KGXsXoVxFiEJpfQ==}
     engines: {node: '>=16.0.0'}
 
-  '@usecannon/cli@2.26.0-alpha.0':
-    resolution: {integrity: sha512-0+OBLmW0Mc6L4VtzEm39uTNOAueIr0ntOGurx/o9zkPm/3JEaomNcLcpgO5kpdccwUaAly+sl2eoV+PejvZeig==}
+  '@usecannon/cli@2.26.0':
+    resolution: {integrity: sha512-eGgfTcAqRZua3+vDEtatpzp71UzdIMpMJxniua0WL6tm7GllAl+XiZ21/9OI1EhuOS3TPcwAUUMqOIx4Yl+r8w==}
     hasBin: true
 
   '@usecannon/router@4.1.3':
@@ -1211,7 +1211,7 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@usecannon/builder@2.26.0-alpha.0':
+  '@usecannon/builder@2.26.0':
     dependencies:
       '@usecannon/router': 4.1.3
       '@usecannon/web-solc': 0.5.1
@@ -1240,10 +1240,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@usecannon/cli@2.26.0-alpha.0':
+  '@usecannon/cli@2.26.0':
     dependencies:
       '@iarna/toml': 3.0.0
-      '@usecannon/builder': 2.26.0-alpha.0
+      '@usecannon/builder': 2.26.0
       abitype: 1.2.3(zod@3.25.76)
       chalk: 4.1.2
       commander: 12.1.0


### PR DESCRIPTION
## Description

Update the deployment package for Euler Integration contracts.

## Context

* use updated wrapper implementations post-audit. This includes a high severity issue where the EIP-712 type hash was incorrect for the `CollateralSwapWrapper`
* add CowWrapperHelpers. This contract was added because we don't really have another great place to deploy it, and the deployed contract addresses are linked to from the docs pr https://github.com/cowprotocol/docs/pull/595

## Testing Instructions

Confirm the cannonfile changes look as expected
Confirm that the build works (tested by CI)
Double check the address deployed for the CowWrapperHelpers matches production expected in the docs PR above.
