### PR TITLE
fix: configure wrapper helpers with authenticator

### DIFF
--- a/cannonfile.toml
+++ b/cannonfile.toml
@@ -57,7 +57,7 @@ artifact = "CowWrapperHelpers"
 create2 = true
 ifExists = "continue"
 salt = "<%= settings.wrapperHelpersSalt %>"
-args = ["<%= settings.cowSettlementAddress %>"]
+args = ["<%= cow.Authenticator.address %>"]
 
 # Authorise these wrappers as a solvers
 [invoke.authorizeOpenWrapper]


### PR DESCRIPTION
## Summary

`CowWrapperHelpers` deployments now receive CoW Protocol's Authenticator, so their solver-authorization checks call the contract that implements `isSolver` instead of treating Settlement as the authenticator.

This is a focused fix stacked on the deployment release in PR #25.

## Validation

- `forge test` — 133 passed, 0 failed, 7 skipped

Related: #25
